### PR TITLE
Fix plots, barbell rendering, and Optimize All Tabs chaining

### DIFF
--- a/src/movement_optimizer/gui.py
+++ b/src/movement_optimizer/gui.py
@@ -559,8 +559,9 @@ class ExerciseTab(QWidget):
             2,
             4,
             figure=self.fig,
-            hspace=0.38,
-            wspace=0.38,
+            height_ratios=[2, 1],
+            hspace=0.35,
+            wspace=0.40,
             left=0.06,
             right=0.97,
             top=0.92,
@@ -577,7 +578,7 @@ class ExerciseTab(QWidget):
         for ax in self.axes.values():
             style_axis(ax)
 
-        self.axes["anim"].set_aspect("equal")
+        self.axes["anim"].set_aspect("equal", adjustable="datalim")
         self.axes["anim"].set_xlim(-0.9, 0.9)
         self.axes["anim"].set_ylim(-0.15, 1.8)
         self.axes["anim"].text(
@@ -908,6 +909,7 @@ class MainWindow(QMainWindow):
         self.anim_timer.timeout.connect(self._anim_step)
 
         self._cancel_event = threading.Event()
+        self._opt_running = False
         self._cache = SolutionCache()
 
         self._build_ui()
@@ -986,6 +988,7 @@ class MainWindow(QMainWindow):
     def _run_exercise(self, idx: int, then_chain: list[int] | None = None) -> None:
         self._stop_anim()
         self._cancel_event.clear()
+        self._opt_running = True
         self.sidebar.show_optimizing()
         name = self.EXERCISE_CONFIGS[idx][0]
         self.status_label.setText(f"Optimizing {name}...")
@@ -1095,10 +1098,12 @@ class MainWindow(QMainWindow):
             QTimer.singleShot(100, self._ensure_idle)
 
     def _ensure_idle(self) -> None:
-        """Safety net: if the sidebar is still in 'optimizing' state
-        after the worker thread finished, force it back to idle.
-        This catches any unhandled exception in _on_done rendering.
+        """Safety net: force UI back to idle if the worker is done but
+        the sidebar is still locked.  Skips if another optimization is
+        actively running (e.g. chaining exercises).
         """
+        if self._opt_running:
+            return
         if not self.sidebar.opt_btn.isEnabled():
             logger.warning("UI was stuck in optimizing state — forcing idle")
             self.sidebar.show_idle()
@@ -1155,9 +1160,11 @@ class MainWindow(QMainWindow):
                 next_idx = then_chain.pop(0)
                 self._run_exercise(next_idx, then_chain or None)
             else:
+                self._opt_running = False
                 self.sidebar.show_idle()
                 self.status_label.setText(status_msg)
         except Exception:
+            self._opt_running = False
             tb = traceback.format_exc()
             logger.error("Error in _on_done:\n%s", tb)
             print(f"ERROR in _on_done:\n{tb}", flush=True)
@@ -1165,6 +1172,7 @@ class MainWindow(QMainWindow):
             self.status_label.setText(f"Render error: {tb.splitlines()[-1]}")
 
     def _on_cancelled(self) -> None:
+        self._opt_running = False
         self.sidebar.show_idle()
         self.sidebar.prog_label.setText("Cancelled")
         self.status_label.setText("Optimization cancelled by user.")
@@ -1185,6 +1193,7 @@ class MainWindow(QMainWindow):
         )
 
     def _on_err(self, msg: str) -> None:
+        self._opt_running = False
         self.sidebar.show_idle()
         self.status_label.setText(f"Error: {msg}")
         QMessageBox.critical(self, "Error", msg)

--- a/src/movement_optimizer/rendering.py
+++ b/src/movement_optimizer/rendering.py
@@ -11,7 +11,7 @@ Design Principles:
 from __future__ import annotations
 
 from matplotlib.axes import Axes
-from matplotlib.patches import Circle, Rectangle
+from matplotlib.patches import Circle
 from numpy.typing import NDArray
 
 from .constants import BAR_RADIUS_M, PLATE_RADIUS_STD_M
@@ -38,46 +38,52 @@ class Palette:
 
 
 class BarbellRenderer:
-    """Draw barbell as sagittal cross-section."""
+    """Draw barbell as seen from the side (sagittal plane).
 
-    BAR_ALPHA = 0.50
-    PLATE_ALPHA = 0.55
-    BAR_COLOR = "#d4a017"
-    PLATE_COLOR = "#777777"
+    From the side, a loaded barbell appears as a large circle (the plate)
+    with a smaller concentric circle (the bar shaft).
+    """
+
+    BAR_ALPHA = 0.60
+    PLATE_ALPHA = 0.50
+    BAR_COLOR = "#c0c0c0"
+    BAR_EDGE = "#888888"
+    PLATE_COLOR = "#444444"
+    PLATE_EDGE = "#333333"
 
     @classmethod
     def draw(cls, ax: Axes, position: tuple[float, float]) -> None:
         x, y = position
+        cls._draw_plate_circle(ax, x, y)
         cls._draw_bar_circle(ax, x, y)
-        cls._draw_plate_rect(ax, x, y)
+
+    @classmethod
+    def _draw_plate_circle(cls, ax: Axes, x: float, y: float) -> None:
+        """Outer plate circle — the bumper plate seen from the side."""
+        ax.add_patch(
+            Circle(
+                (x, y),
+                PLATE_RADIUS_STD_M,
+                facecolor=cls.PLATE_COLOR,
+                edgecolor=cls.PLATE_EDGE,
+                linewidth=1.5,
+                alpha=cls.PLATE_ALPHA,
+                zorder=7,
+            )
+        )
 
     @classmethod
     def _draw_bar_circle(cls, ax: Axes, x: float, y: float) -> None:
+        """Inner bar shaft circle — the bar cross-section."""
         ax.add_patch(
             Circle(
                 (x, y),
                 BAR_RADIUS_M,
                 facecolor=cls.BAR_COLOR,
-                edgecolor="#8B7500",
+                edgecolor=cls.BAR_EDGE,
                 linewidth=1.5,
                 alpha=cls.BAR_ALPHA,
                 zorder=8,
-            )
-        )
-
-    @classmethod
-    def _draw_plate_rect(cls, ax: Axes, x: float, y: float) -> None:
-        pw = 0.025
-        ax.add_patch(
-            Rectangle(
-                (x - pw / 2, y - PLATE_RADIUS_STD_M),
-                pw,
-                2 * PLATE_RADIUS_STD_M,
-                facecolor=cls.PLATE_COLOR,
-                edgecolor="#555",
-                linewidth=1,
-                alpha=cls.PLATE_ALPHA,
-                zorder=7,
             )
         )
 


### PR DESCRIPTION
## Summary
- **Plots visible**: height_ratios=[2,1] + adjustable='datalim' on animation axes prevents matplotlib from squishing analysis plots
- **Barbell**: plate rendered as large circle (side view), bar shaft as small inner circle -- proper sagittal plane appearance
- **Optimize All Tabs**: _ensure_idle no longer kills the exercise chain by premature show_idle()

## Test plan
- [x] 67 tests passing, ruff clean
- [ ] Manual: all 5 analysis plots visible below animation
- [ ] Manual: Optimize All Tabs chains through all 3 exercises
- [ ] Manual: barbell appears as concentric circles (plate + shaft)

Generated with [Claude Code](https://claude.com/claude-code)