### PR TITLE
Fix neck rendering, bar-knee clearance for all pulls

### DIFF
--- a/src/movement_optimizer/constants.py
+++ b/src/movement_optimizer/constants.py
@@ -30,7 +30,18 @@ LENGTH_FRAC: dict[str, float] = {
     "torso": 0.288,
     "arm": 0.387,
     "foot": 0.152,
+    "neck": 0.075,  # C7 to base of skull, ~7.5% of height
 }
+
+# ------------------------------------------------------------------
+# Neck joint angle limit (degrees)
+#
+# The neck can tilt up to 45 degrees in any direction relative to the
+# torso.  The 2-D model does not currently have a separate neck DOF,
+# but the constant is documented here so the rendering keeps the neck
+# roughly aligned with the torso.
+# ------------------------------------------------------------------
+NECK_MAX_ANGLE_DEG: float = 45.0
 
 # ------------------------------------------------------------------
 # COM position as fraction of segment length from proximal joint

--- a/src/movement_optimizer/rendering.py
+++ b/src/movement_optimizer/rendering.py
@@ -10,11 +10,15 @@ Design Principles:
 
 from __future__ import annotations
 
+import numpy as np
 from matplotlib.axes import Axes
 from matplotlib.patches import Circle
 from numpy.typing import NDArray
 
-from .constants import BAR_RADIUS_M, PLATE_RADIUS_STD_M
+from .constants import BAR_RADIUS_M, LENGTH_FRAC, PLATE_RADIUS_STD_M
+
+# Neck length as a fraction of body height (used by BodyRenderer)
+NECK_LENGTH_FRAC: float = LENGTH_FRAC["neck"]
 
 
 class Palette:
@@ -104,7 +108,9 @@ class BodyRenderer:
         )
 
     @classmethod
-    def draw_ghost(cls, ax: Axes, joints: dict[str, NDArray], alpha: float = 0.10) -> None:
+    def draw_ghost(
+        cls, ax: Axes, joints: dict[str, NDArray], alpha: float = 0.10, body_height: float = 1.75
+    ) -> None:
         pts = [joints["ankle"], joints["knee"], joints["hip"], joints["shoulder"]]
         for k in range(3):
             ax.plot(
@@ -115,13 +121,35 @@ class BodyRenderer:
                 lw=2,
                 alpha=alpha,
             )
+        # Ghost neck + head
+        neck_length = NECK_LENGTH_FRAC * body_height
+        shoulder = joints["shoulder"]
+        neck_top = np.array([shoulder[0], shoulder[1] + neck_length])
+        ax.plot(
+            [shoulder[0], neck_top[0]],
+            [shoulder[1], neck_top[1]],
+            "-",
+            color=Palette.FG,
+            lw=2,
+            alpha=alpha,
+        )
+        ax.add_patch(
+            Circle(
+                (neck_top[0], neck_top[1] + cls.HEAD_RADIUS),
+                cls.HEAD_RADIUS,
+                facecolor=Palette.FG,
+                edgecolor="none",
+                alpha=alpha,
+                zorder=6,
+            )
+        )
 
     # Linewidths per segment: shank (thinner), thigh (medium), torso (thick)
     SEG_LINEWIDTHS = (6, 9, 12)
     HEAD_RADIUS = 0.10  # metres
 
     @classmethod
-    def draw_segments(cls, ax: Axes, joints: dict[str, NDArray]) -> None:
+    def draw_segments(cls, ax: Axes, joints: dict[str, NDArray], body_height: float = 1.75) -> None:
         pts = [joints["ankle"], joints["knee"], joints["hip"], joints["shoulder"]]
         for k in range(3):
             ax.plot(
@@ -142,13 +170,25 @@ class BodyRenderer:
                 markeredgecolor="#333",
                 markeredgewidth=1.2,
             )
-        # Draw head above the shoulder joint
-        cls.draw_head(ax, joints["shoulder"])
+        # Draw neck segment from shoulder upward
+        neck_length = NECK_LENGTH_FRAC * body_height
+        shoulder = joints["shoulder"]
+        neck_top = np.array([shoulder[0], shoulder[1] + neck_length])
+        ax.plot(
+            [shoulder[0], neck_top[0]],
+            [shoulder[1], neck_top[1]],
+            "-",
+            color="#d4a574",
+            lw=5,
+            solid_capstyle="round",
+        )
+        # Draw head at top of neck
+        cls.draw_head(ax, neck_top)
 
     @classmethod
-    def draw_head(cls, ax: Axes, shoulder: NDArray) -> None:
-        """Draw a circle representing the head above the shoulder joint."""
-        head_center = (shoulder[0], shoulder[1] + cls.HEAD_RADIUS)
+    def draw_head(cls, ax: Axes, neck_top: NDArray) -> None:
+        """Draw a circle representing the head above the top of the neck."""
+        head_center = (neck_top[0], neck_top[1] + cls.HEAD_RADIUS)
         ax.add_patch(
             Circle(
                 head_center,

--- a/src/movement_optimizer/trajectory.py
+++ b/src/movement_optimizer/trajectory.py
@@ -377,11 +377,11 @@ class TrajectoryOptimizer:
         return np.concatenate([lower, upper])
 
     def _bar_knee_clearance(self, x: NDArray) -> NDArray:
-        """Bar must stay in front of the knees during deadlift.
+        """Bar must stay in front of the knees during pulling exercises.
 
         Returns array of length n_eval:
             bar_x - knee_x + margin  (must be >= 0)
-        Only active for deadlift exercises.
+        Active for deadlift, clean, and snatch exercises.
         """
         splines = self.build_splines(x)
         q = np.column_stack([s(self.t_eval) for s in splines])
@@ -389,10 +389,10 @@ class TrajectoryOptimizer:
         knee_x = L[0] * np.sin(q[:, 0])
         hip_x = knee_x + L[1] * np.sin(q[:, 1])
         shoulder_x = hip_x + L[2] * np.sin(q[:, 2])
-        # For deadlift, bar hangs from shoulders (at arm length below)
+        # For pulling exercises, bar hangs from shoulders (at arm length below)
         # Bar x == shoulder x in sagittal plane
         bar_x = shoulder_x
-        clearance = 0.02  # 2cm minimum clearance
+        clearance = 0.05  # 5cm minimum bar-to-knee clearance
         return bar_x - knee_x + clearance
 
     # ==========================================================
@@ -557,7 +557,8 @@ class TrajectoryOptimizer:
         constraints = [
             {"type": "ineq", "fun": self._com_constraint_values},
         ]
-        if self.exercise_type == "deadlift":
+        pulling_exercises = {"deadlift", "clean", "snatch"}
+        if self.exercise_type in pulling_exercises:
             constraints.append(
                 {"type": "ineq", "fun": self._bar_knee_clearance},
             )

--- a/tests/test_neck.py
+++ b/tests/test_neck.py
@@ -1,0 +1,18 @@
+"""Tests for neck rendering constants and visual properties."""
+
+from __future__ import annotations
+
+from movement_optimizer.constants import LENGTH_FRAC, NECK_MAX_ANGLE_DEG
+from movement_optimizer.rendering import NECK_LENGTH_FRAC
+
+
+class TestNeckRendering:
+    def test_neck_length_in_constants(self) -> None:
+        assert "neck" in LENGTH_FRAC
+        assert 0.05 < LENGTH_FRAC["neck"] < 0.15
+
+    def test_neck_max_angle(self) -> None:
+        assert NECK_MAX_ANGLE_DEG == 45.0
+
+    def test_neck_length_frac_matches_constants(self) -> None:
+        assert LENGTH_FRAC["neck"] == NECK_LENGTH_FRAC

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -12,8 +12,11 @@ import threading
 import numpy as np
 import pytest
 
+from movement_optimizer.exercises import make_clean_config, make_snatch_config
 from movement_optimizer.models import (
     BodyModel,
+    make_bench_press_config,
+    make_deadlift_config,
     make_full_squat_config,
     make_squat_config,
 )
@@ -524,3 +527,106 @@ class TestSolutionCache:
         cache.put("squat", 75.0, 1.75, mults, 60.0, 2.0, 1.0, dummy)
         cache.clear()
         assert cache.get("squat", 75.0, 1.75, mults, 60.0, 2.0, 1.0) is None
+
+
+# ==============================================================
+# Bar-Knee Clearance
+# ==============================================================
+
+
+def _has_bar_knee_constraint(opt: TrajectoryOptimizer) -> bool:
+    """Return True if the optimizer's constraints include bar-knee clearance."""
+    constraints = opt._build_constraints()
+    return any(
+        getattr(c["fun"], "__func__", None) is TrajectoryOptimizer._bar_knee_clearance
+        for c in constraints
+    )
+
+
+class TestBarKneeClearance:
+    def test_clearance_active_for_deadlift(self) -> None:
+        body = BodyModel(75.0, 1.75)
+        dyn, qs, qe, qb = make_deadlift_config(body, 60.0)
+        opt = TrajectoryOptimizer(
+            body,
+            dyn,
+            "deadlift",
+            60.0,
+            qs,
+            qe,
+            qb,
+            n_waypoints=6,
+            n_eval=20,
+            n_starts=1,
+        )
+        assert _has_bar_knee_constraint(opt)
+
+    def test_clearance_active_for_clean(self) -> None:
+        body = BodyModel(75.0, 1.75)
+        dyn, qs, qe, qb, q_via = make_clean_config(body, 60.0)
+        opt = TrajectoryOptimizer(
+            body,
+            dyn,
+            "clean",
+            60.0,
+            qs,
+            qe,
+            qb,
+            q_via=q_via,
+            n_waypoints=6,
+            n_eval=20,
+            n_starts=1,
+        )
+        assert _has_bar_knee_constraint(opt)
+
+    def test_clearance_active_for_snatch(self) -> None:
+        body = BodyModel(75.0, 1.75)
+        dyn, qs, qe, qb, q_via = make_snatch_config(body, 60.0)
+        opt = TrajectoryOptimizer(
+            body,
+            dyn,
+            "snatch",
+            60.0,
+            qs,
+            qe,
+            qb,
+            q_via=q_via,
+            n_waypoints=6,
+            n_eval=20,
+            n_starts=1,
+        )
+        assert _has_bar_knee_constraint(opt)
+
+    def test_clearance_not_active_for_squat(self) -> None:
+        body = BodyModel(75.0, 1.75)
+        dyn, qs, qe, qb = make_squat_config(body, 60.0)
+        opt = TrajectoryOptimizer(
+            body,
+            dyn,
+            "squat",
+            60.0,
+            qs,
+            qe,
+            qb,
+            n_waypoints=6,
+            n_eval=20,
+            n_starts=1,
+        )
+        assert not _has_bar_knee_constraint(opt)
+
+    def test_clearance_not_active_for_bench(self) -> None:
+        body = BodyModel(75.0, 1.75)
+        dyn, qs, qe, qb, _q_via = make_bench_press_config(body, 60.0)
+        opt = TrajectoryOptimizer(
+            body,
+            dyn,
+            "bench_press",
+            60.0,
+            qs,
+            qe,
+            qb,
+            n_waypoints=6,
+            n_eval=20,
+            n_starts=1,
+        )
+        assert not _has_bar_knee_constraint(opt)


### PR DESCRIPTION
## Summary
- **Neck**: 7.5% body height neck segment between shoulder and head. Head at top of neck.
- **Bar-knee clearance**: extended to clean and snatch (was only deadlift). Increased from 2cm to 5cm.
- **Neck limits**: NECK_MAX_ANGLE_DEG = 45 constant added.

## Tests
251 tests passing (8 new: 3 neck + 5 bar-knee constraint coverage)

Generated with [Claude Code](https://claude.com/claude-code)