### PR TITLE
Fix bench press bar trace and motion balance

### DIFF
--- a/src/movement_optimizer/_gui_impl.py
+++ b/src/movement_optimizer/_gui_impl.py
@@ -1077,10 +1077,13 @@ class ExerciseTab(QWidget):
             )
 
         # Bar at hand position (end of chain)
-        BarbellRenderer.draw(ax, (arm_joints[-1][0], arm_joints[-1][1]))
+        bar_pos = arm_joints[-1]
+        BarbellRenderer.draw(ax, (bar_pos[0], bar_pos[1]))
 
-        # Bar trace
-        BodyRenderer.draw_bar_trace(ax, result.bar, fi)
+        # Bar trace — offset the FK-based trace to bench coordinates
+        bar_trace_offset = arm_base - fk_points[0]
+        bench_bar_traj = result.bar + bar_trace_offset
+        BodyRenderer.draw_bar_trace(ax, bench_bar_traj, fi)
 
         ax.set_title(
             f"{self.name}  t={t_now:.2f}s  |  "

--- a/src/movement_optimizer/constants.py
+++ b/src/movement_optimizer/constants.py
@@ -150,8 +150,8 @@ BENCH_UPPER_ARM_FRAC: float = 0.56  # shoulder to elbow (anatomical ~48% + shoul
 BENCH_FOREARM_FRAC: float = 0.38  # elbow to wrist (anatomical ~38%)
 
 BENCH_PRESS_JOINT_LIMITS: dict[str, tuple[float, float]] = {
-    "shoulder": (np.radians(-10), np.radians(100)),
-    "elbow": (np.radians(-140), np.radians(10)),
+    "shoulder": (np.radians(-5), np.radians(95)),  # main driver of the press
+    "elbow": (np.radians(-110), np.radians(5)),  # tighter: lockout to ~110 deg flexion
     "wrist": (np.radians(-1), np.radians(1)),  # effectively locked straight
 }
 

--- a/src/movement_optimizer/trajectory.py
+++ b/src/movement_optimizer/trajectory.py
@@ -420,8 +420,14 @@ class TrajectoryOptimizer:
             + self._endpoint_damping_cost(qd, qdd)
         )
 
-        # Bench press: no balance cost (lifter is on a bench)
-        if self.exercise_type != "bench_press":
+        if self.exercise_type == "bench_press":
+            # Bar-path verticality: penalise horizontal drift from shoulder joint.
+            # In bench FK, origin=shoulder, segments are upper_arm→forearm→hand.
+            # hand_x = sum of L[i]*sin(q[i]) — should stay near zero (bar above shoulder).
+            L = self.dynamics.L
+            hand_x = L[0] * np.sin(q[:, 0]) + L[1] * np.sin(q[:, 1]) + L[2] * np.sin(q[:, 2])
+            total += 500.0 * float(np.sum(hand_x**2)) * self.dt
+        else:
             com_x = self.dynamics.com_x_batch(q, self.exercise_type, self.bar_mass)
             total += self._balance_cost(com_x)
 


### PR DESCRIPTION
## Summary
- Bar trace now correctly tracks the barbell position in bench coordinates
- Bar-path verticality cost (weight=500) keeps bar above shoulder, preventing excessive elbow-only motion
- Elbow bounds tightened to -110° to +5° for more realistic ROM

## Tests
254 passing

Generated with [Claude Code](https://claude.com/claude-code)