### PR TITLE
fix: critical GUI/dynamics bugs and round-2 quality improvements

### DIFF
--- a/src/movement_optimizer/comparison.py
+++ b/src/movement_optimizer/comparison.py
@@ -16,6 +16,7 @@ from typing import Any
 
 import numpy as np
 
+from .constants import trapezoid
 from .trajectory import OptimizationResult
 
 
@@ -82,8 +83,7 @@ def comparison_metrics(trials: list[dict[str, Any]]) -> list[dict[str, Any]]:
     for trial in trials:
         r: OptimizationResult = trial["result"]
         peak_torques = [float(np.max(np.abs(r.torques[:, j]))) for j in range(3)]
-        dt = float(r.t[1] - r.t[0]) if len(r.t) > 1 else 1.0
-        total_work = float(np.sum(np.abs(r.power)) * dt)
+        total_work = float(trapezoid(np.abs(r.power).sum(axis=1), r.t))
         com_sway_cm = float(r.com_horizontal_range_cm)
 
         metrics.append(

--- a/src/movement_optimizer/constants.py
+++ b/src/movement_optimizer/constants.py
@@ -15,7 +15,7 @@ import numpy as np
 # ------------------------------------------------------------------
 MASS_FRAC: dict[str, float] = {
     "feet": 0.028,
-    "lower_legs": 0.093,
+    "lower_legs": 0.094,
     "upper_legs": 0.200,
     "trunk_head": 0.578,
     "arms": 0.100,
@@ -174,6 +174,23 @@ BENCH_PRESS_HILL_OPTIMAL_ANGLES: dict[str, float] = {
 # The outer 20% on each end is excluded.
 # ------------------------------------------------------------------
 BOS_INNER_FRACTION: float = 0.60
+
+# ------------------------------------------------------------------
+# Trajectory optimisation tuning constants
+# ------------------------------------------------------------------
+
+# Bench press bar-path penalty weight: penalises horizontal deviation of
+# the bar (hand position) from a vertical path during the press.
+BENCH_BAR_PATH_WEIGHT: float = 500.0
+
+# Total-variation weight ratio: TV regularisation is this fraction of the
+# L2 torque-rate regularisation term.
+TV_RATE_WEIGHT_RATIO: float = 0.1
+
+# Minimum bar-to-knee clearance for pulling exercises (deadlift, clean,
+# snatch).  The bar must stay at least this many metres in front of the
+# knees throughout the lift.
+BAR_KNEE_CLEARANCE_M: float = 0.05
 
 # numpy compat shim  (trapz renamed to trapezoid in numpy 2.0)
 trapezoid = getattr(np, "trapezoid", getattr(np, "trapz", None))

--- a/src/movement_optimizer/gui/main_window.py
+++ b/src/movement_optimizer/gui/main_window.py
@@ -19,7 +19,6 @@ import csv
 import json
 import logging
 import os
-import sys
 import threading
 import traceback
 from collections.abc import Callable
@@ -348,7 +347,6 @@ class MainWindow(QMainWindow):
         self._stop_anim()
         self._cancel_event.set()
         event.accept()
-        sys.exit(0)
 
     def _save_session_state(self) -> None:
         """Persist current results and slider values on close."""
@@ -541,6 +539,10 @@ class MainWindow(QMainWindow):
             self._sig_done.emit(idx, result, body, bar, then_chain)
         except CancelledError:
             self._sig_cancelled.emit()
+        except NotImplementedError as exc:
+            tb = traceback.format_exc()
+            logger.error("Optimisation failed (feature not implemented):\n%s", tb)
+            self._sig_error.emit(f"Feature not yet implemented: {exc}")
         except (ValueError, RuntimeError, OSError, np.linalg.LinAlgError) as exc:
             tb = traceback.format_exc()
             logger.error("Optimisation failed:\n%s", tb)

--- a/src/movement_optimizer/gui/widgets.py
+++ b/src/movement_optimizer/gui/widgets.py
@@ -178,6 +178,12 @@ class ParameterSidebar(QScrollArea):
         model_row.addWidget(QLabel("Model:"))
         self.model_combo = QComboBox()
         self.model_combo.addItems(["2D Sagittal", "3D Bilateral"])
+        # Disable 3D mode until forward kinematics is implemented
+        idx_3d = self.model_combo.findText("3D Bilateral")
+        if idx_3d >= 0:
+            item = self.model_combo.model().item(idx_3d)
+            item.setEnabled(False)
+            item.setToolTip("3D mode not yet implemented")
         model_row.addWidget(self.model_combo)
         lay.addLayout(model_row)
 

--- a/src/movement_optimizer/models.py
+++ b/src/movement_optimizer/models.py
@@ -541,47 +541,69 @@ class LagrangianDynamics(PhysicsBackend):
         m_segments: NDArray,
         I_segments: NDArray,
         load_mass: float,
+        body_override: dict[str, NDArray] | None = None,
     ) -> None:
+        """Initialise Lagrangian dynamics for a 3-link planar chain.
+
+        Parameters:
+            body: Anthropometric model (used for g, BOS, and default geometry).
+            m_segments: Length-3 array of segment masses (kg).
+            I_segments: Length-3 array of segment moments of inertia (kg·m²).
+            load_mass: Mass of the external load at the chain tip (kg).
+            body_override: Optional dict with keys 'L', 'd' containing
+                length-3 NDArrays that override the body geometry for the
+                coupling-coefficient calculations.  Used by non-leg kinematic
+                chains (e.g. the arm chain for bench press) without resorting
+                to post-hoc attribute surgery.
+        """
         if len(m_segments) != 3:
             raise ValueError("need 3 segment masses")
         if load_mass < 0:
             raise ValueError("load_mass cannot be negative")
         self.body = body
-        self.L = body.L
-        self.L_eff = body.L_eff
-        self.d = body.d
-        self.d_eff = body.d_eff
         self.m = m_segments
         self.I = I_segments
         self.m_load = load_mass
         self.g = body.g
 
+        # Allow callers to supply alternative segment geometry (e.g. arm chain).
+        if body_override is not None:
+            L = body_override["L"]
+            d = body_override["d"]
+            self.L = L
+            self.L_eff = L.copy()
+            self.d = d
+            self.d_eff = d.copy()
+        else:
+            self.L = body.L
+            self.L_eff = body.L_eff
+            self.d = body.d
+            self.d_eff = body.d_eff
+            L = body.L
+            d = body.d
+
         # Pre-compute coupling coefficients (constant for given model)
-        self._a01 = (m_segments[1] * body.d[1] + (m_segments[2] + load_mass) * body.L[1]) * body.L[
-            0
-        ]
-        self._a02 = (m_segments[2] * body.d[2] + load_mass * body.L[2]) * body.L[0]
-        self._a12 = (m_segments[2] * body.d[2] + load_mass * body.L[2]) * body.L[1]
+        self._a01 = (m_segments[1] * d[1] + (m_segments[2] + load_mass) * L[1]) * L[0]
+        self._a02 = (m_segments[2] * d[2] + load_mass * L[2]) * L[0]
+        self._a12 = (m_segments[2] * d[2] + load_mass * L[2]) * L[1]
 
         # Diagonal mass-matrix constants
         self._M00 = (
-            m_segments[0] * body.d[0] ** 2
-            + (m_segments[1] + m_segments[2] + load_mass) * body.L[0] ** 2
+            m_segments[0] * d[0] ** 2
+            + (m_segments[1] + m_segments[2] + load_mass) * L[0] ** 2
             + I_segments[0]
         )
         self._M11 = (
-            m_segments[1] * body.d[1] ** 2
-            + (m_segments[2] + load_mass) * body.L[1] ** 2
-            + I_segments[1]
+            m_segments[1] * d[1] ** 2 + (m_segments[2] + load_mass) * L[1] ** 2 + I_segments[1]
         )
-        self._M22 = m_segments[2] * body.d[2] ** 2 + load_mass * body.L[2] ** 2 + I_segments[2]
+        self._M22 = m_segments[2] * d[2] ** 2 + load_mass * L[2] ** 2 + I_segments[2]
 
         # Gravity coefficients
         self._g0 = body.g * (
-            m_segments[0] * body.d[0] + (m_segments[1] + m_segments[2] + load_mass) * body.L[0]
+            m_segments[0] * d[0] + (m_segments[1] + m_segments[2] + load_mass) * L[0]
         )
-        self._g1 = body.g * (m_segments[1] * body.d[1] + (m_segments[2] + load_mass) * body.L[1])
-        self._g2 = body.g * (m_segments[2] * body.d[2] + load_mass * body.L[2])
+        self._g1 = body.g * (m_segments[1] * d[1] + (m_segments[2] + load_mass) * L[1])
+        self._g2 = body.g * (m_segments[2] * d[2] + load_mass * L[2])
 
     @property
     def n_dof(self) -> int:
@@ -733,7 +755,14 @@ class LagrangianDynamics(PhysicsBackend):
         fk = self.forward_kinematics(q)
         s = fk["shoulder"]
         if exercise_type == "deadlift":
+            # Bar hangs from hands: arm-length below shoulder
             return np.array([s[0], s[1] - self.body.L_arm])
+        if exercise_type in ("clean", "clean_and_jerk"):
+            # Front rack: bar sits at shoulder height
+            return s.copy()
+        if exercise_type in ("snatch", "jerk"):
+            # Overhead: bar is arm-length above shoulder
+            return np.array([s[0], s[1] + self.body.L_arm])
         return s.copy()
 
     def com_position(
@@ -955,28 +984,16 @@ def make_bench_press_config(
     """
     bp = BenchPressModel(body)
 
-    # Create a dynamics object using arm segment properties
-    # For bench press, the load (bar) is at the end of the chain (hands)
-    dyn = LagrangianDynamics(body, bp.m.copy(), bp.I.copy(), bar_mass)
-    # Override segment lengths for arm chain
-    dyn.L = bp.L
-    dyn.L_eff = bp.L.copy()
-    dyn.d = bp.d
-    dyn.d_eff = bp.d.copy()
-
-    # Recompute coupling coefficients for arm geometry
-    m = bp.m
-    d = bp.d
-    L = bp.L
-    dyn._a01 = (m[1] * d[1] + (m[2] + bar_mass) * L[1]) * L[0]
-    dyn._a02 = (m[2] * d[2] + bar_mass * L[2]) * L[0]
-    dyn._a12 = (m[2] * d[2] + bar_mass * L[2]) * L[1]
-    dyn._M00 = m[0] * d[0] ** 2 + (m[1] + m[2] + bar_mass) * L[0] ** 2 + bp.I[0]
-    dyn._M11 = m[1] * d[1] ** 2 + (m[2] + bar_mass) * L[1] ** 2 + bp.I[1]
-    dyn._M22 = m[2] * d[2] ** 2 + bar_mass * L[2] ** 2 + bp.I[2]
-    dyn._g0 = body.g * (m[0] * d[0] + (m[1] + m[2] + bar_mass) * L[0])
-    dyn._g1 = body.g * (m[1] * d[1] + (m[2] + bar_mass) * L[1])
-    dyn._g2 = body.g * (m[2] * d[2] + bar_mass * L[2])
+    # Create a dynamics object using arm segment properties.
+    # Pass body_override so the constructor uses arm geometry (L, d) for all
+    # coupling-coefficient calculations — no post-hoc attribute surgery needed.
+    dyn = LagrangianDynamics(
+        body,
+        bp.m.copy(),
+        bp.I.copy(),
+        bar_mass,
+        body_override={"L": bp.L, "d": bp.d},
+    )
 
     # Start: lockout (arms straight up, perpendicular to supine body)
     q_start = np.array([np.radians(0), np.radians(0), np.radians(0)])

--- a/src/movement_optimizer/trajectory/__init__.py
+++ b/src/movement_optimizer/trajectory/__init__.py
@@ -1,4 +1,5 @@
 """Trajectory module extracted from monolith."""
+
 from __future__ import annotations
 
 from .cache import SolutionCache as SolutionCache

--- a/src/movement_optimizer/trajectory/cache.py
+++ b/src/movement_optimizer/trajectory/cache.py
@@ -1,4 +1,5 @@
 """Thread-safe cache for optimisation solutions."""
+
 from __future__ import annotations
 
 import hashlib
@@ -9,6 +10,7 @@ import threading
 from .result import OptimizationResult
 
 logger = logging.getLogger(__name__)
+
 
 class SolutionCache:
     """Thread-safe cache of optimisation results keyed by config hash."""

--- a/src/movement_optimizer/trajectory/optimizer.py
+++ b/src/movement_optimizer/trajectory/optimizer.py
@@ -1,4 +1,5 @@
 """Parallel multi-start trajectory optimiser engine."""
+
 from __future__ import annotations
 
 import logging
@@ -14,6 +15,7 @@ from scipy.interpolate import CubicSpline
 from scipy.optimize import minimize
 
 from ..backend import PhysicsBackend
+from ..constants import BAR_KNEE_CLEARANCE_M, BENCH_BAR_PATH_WEIGHT, TV_RATE_WEIGHT_RATIO
 from ..models import BodyModel
 from .result import CancelledError, OptimizationResult, ProgressReport
 from .tuning import (
@@ -30,6 +32,7 @@ from .tuning import (
 )
 
 logger = logging.getLogger(__name__)
+
 
 class TrajectoryOptimizer:
     """Parallel multi-start trajectory optimiser.
@@ -168,7 +171,7 @@ class TrajectoryOptimizer:
         """
         dtau = np.diff(torques, axis=0) / self.dt
         l2_cost = float(np.sum(dtau**2)) * self.dt
-        tv_cost = float(np.sum(np.abs(dtau))) * self.dt * 0.1
+        tv_cost = float(np.sum(np.abs(dtau))) * self.dt * TV_RATE_WEIGHT_RATIO
         return self.torque_rate_weight * (l2_cost + tv_cost)
 
     def _endpoint_damping_cost(self, qd: NDArray, qdd: NDArray) -> float:
@@ -226,8 +229,7 @@ class TrajectoryOptimizer:
         # For pulling exercises, bar hangs from shoulders (at arm length below)
         # Bar x == shoulder x in sagittal plane
         bar_x = shoulder_x
-        clearance = 0.05  # 5cm minimum bar-to-knee clearance
-        return bar_x - knee_x + clearance
+        return bar_x - knee_x + BAR_KNEE_CLEARANCE_M
 
     # ==========================================================
     # Pure cost computation (thread-safe, no side effects)
@@ -260,7 +262,7 @@ class TrajectoryOptimizer:
             # hand_x = sum of L[i]*sin(q[i]) — should stay near zero (bar above shoulder).
             L = self.dynamics.L  # type: ignore[attr-defined]
             hand_x = L[0] * np.sin(q[:, 0]) + L[1] * np.sin(q[:, 1]) + L[2] * np.sin(q[:, 2])
-            total += 500.0 * float(np.sum(hand_x**2)) * self.dt
+            total += BENCH_BAR_PATH_WEIGHT * float(np.sum(hand_x**2)) * self.dt
         else:
             com_x = self.dynamics.com_x_batch(q, self.exercise_type, self.bar_mass)
             total += self._balance_cost(com_x)
@@ -598,16 +600,17 @@ class TrajectoryOptimizer:
 
         success = cost_finite and com_in_bounds
 
-        # Warn if optimized trajectory violates joint limits between control points
+        # Warn and record joint limit violations from spline overshoot
+        n_joint_limit_violations = 0
         if self.q_bounds is not None:
             _lower = np.array([b[0] for b in self.q_bounds])
             _upper = np.array([b[1] for b in self.q_bounds])
-            _n_violated = int(np.sum((q < _lower) | (q > _upper)))
-            if _n_violated > 0:
+            n_joint_limit_violations = int(np.sum((q < _lower) | (q > _upper)))
+            if n_joint_limit_violations > 0:
                 logger.warning(
                     "Trajectory has %d point(s) violating joint limits "
                     "(spline overshoot between control points).",
-                    _n_violated,
+                    n_joint_limit_violations,
                 )
 
         return OptimizationResult(
@@ -624,4 +627,5 @@ class TrajectoryOptimizer:
             com_horizontal_range_cm=com_h_range,
             elapsed_s=elapsed,
             n_evals=n_evals or self._iter,
+            n_joint_limit_violations=n_joint_limit_violations,
         )

--- a/src/movement_optimizer/trajectory/result.py
+++ b/src/movement_optimizer/trajectory/result.py
@@ -1,8 +1,11 @@
 """Data structures for optimisation results."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+
 from numpy.typing import NDArray
+
 
 @dataclass
 class OptimizationResult:
@@ -21,6 +24,8 @@ class OptimizationResult:
     com_horizontal_range_cm: float
     elapsed_s: float = 0.0
     n_evals: int = 0
+    n_joint_limit_violations: int = 0
+
 
 @dataclass
 class ProgressReport:
@@ -34,6 +39,7 @@ class ProgressReport:
     cost_history: list[float] = field(default_factory=list)
     is_stalled: bool = False
     stall_reason: str = ""
+
 
 class CancelledError(Exception):
     """Raised when the user cancels optimisation."""

--- a/tests/test_hypothesis.py
+++ b/tests/test_hypothesis.py
@@ -24,7 +24,7 @@ class TestBodyModelProperties:
         body_mass=st.floats(min_value=30.0, max_value=200.0),
         height=st.floats(min_value=1.2, max_value=2.2),
     )
-    @settings(max_examples=50)
+    @settings(max_examples=100)
     def test_body_model_valid_inputs(self, body_mass: float, height: float):
         """BodyModel should accept any reasonable mass and height."""
         body = BodyModel(body_mass=body_mass, height=height)
@@ -37,7 +37,7 @@ class TestBodyModelProperties:
     @given(
         body_mass=st.floats(min_value=-100.0, max_value=0.0),
     )
-    @settings(max_examples=10)
+    @settings(max_examples=100)
     def test_body_model_rejects_nonpositive_mass(self, body_mass: float):
         """BodyModel should reject non-positive mass."""
         with pytest.raises(ValueError, match="body_mass"):
@@ -48,7 +48,7 @@ class TestBodyModelProperties:
         ul=st.floats(min_value=0.5, max_value=2.0),
         to=st.floats(min_value=0.5, max_value=2.0),
     )
-    @settings(max_examples=30)
+    @settings(max_examples=100)
     def test_segment_multipliers_preserve_proportionality(self, ll: float, ul: float, to: float):
         """Segment lengths should scale linearly with multipliers."""
         base = BodyModel(75.0, 1.75)
@@ -67,7 +67,7 @@ class TestHillTorqueModelProperties:
         q=st.floats(min_value=-2.0, max_value=2.0),
         qd=st.floats(min_value=-10.0, max_value=10.0),
     )
-    @settings(max_examples=50)
+    @settings(max_examples=100)
     def test_available_torque_nonnegative(self, q: float, qd: float):
         """Available torque should always be non-negative."""
         model = HillTorqueModel(tau_max=200.0, q_optimal=1.0)
@@ -77,7 +77,7 @@ class TestHillTorqueModelProperties:
     @given(
         tau_max=st.floats(min_value=10.0, max_value=1000.0),
     )
-    @settings(max_examples=20)
+    @settings(max_examples=100)
     def test_peak_torque_at_optimal_angle(self, tau_max: float):
         """Torque at optimal angle with zero velocity should equal tau_max."""
         model = HillTorqueModel(tau_max=tau_max, q_optimal=1.0)
@@ -91,7 +91,7 @@ class TestClampJointAnglesProperties:
         q1=st.floats(min_value=-3.0, max_value=3.0),
         q2=st.floats(min_value=-3.0, max_value=3.0),
     )
-    @settings(max_examples=50)
+    @settings(max_examples=100)
     def test_clamped_angles_within_limits(self, q0: float, q1: float, q2: float):
         """Clamped angles should always be within joint limits."""
         from movement_optimizer.constants import JOINT_LIMITS, JOINT_NAMES
@@ -110,7 +110,7 @@ class TestInverseDynamicsProperties:
         q1=st.floats(min_value=-1.5, max_value=1.5),
         q2=st.floats(min_value=-1.5, max_value=1.5),
     )
-    @settings(max_examples=30)
+    @settings(max_examples=100)
     def test_static_torques_finite(self, q0: float, q1: float, q2: float):
         """Static torques (zero velocity/acceleration) should be finite."""
         body = BodyModel(75.0, 1.75)
@@ -126,7 +126,7 @@ class TestInverseDynamicsProperties:
         q1=st.floats(min_value=-1.5, max_value=1.5),
         q2=st.floats(min_value=-1.5, max_value=1.5),
     )
-    @settings(max_examples=20)
+    @settings(max_examples=100)
     def test_mass_matrix_positive_definite(self, q0: float, q1: float, q2: float):
         """Mass matrix should be positive definite for any configuration."""
         body = BodyModel(75.0, 1.75)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -36,7 +36,7 @@ class TestBodyModel:
 
     def test_mass_fractions_sum(self, default_body: BodyModel) -> None:
         total = default_body.m_feet + default_body.m_squat.sum()
-        assert abs(total - default_body.body_mass) < 1.0
+        assert abs(total - default_body.body_mass) < 0.01
 
     def test_base_of_support(self, default_body: BodyModel) -> None:
         assert default_body.heel_x < 0

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -630,3 +630,49 @@ class TestBarKneeClearance:
             n_starts=1,
         )
         assert not _has_bar_knee_constraint(opt)
+
+
+# ==============================================================
+# OptimizationResult — joint limit violation tracking
+# ==============================================================
+
+
+class TestJointLimitViolationTracking:
+    """Tests that n_joint_limit_violations is populated in OptimizationResult."""
+
+    def test_no_violations_when_within_limits(self, squat_optimizer) -> None:
+        """A well-behaved trajectory should report zero joint-limit violations."""
+        opt, _body, _dyn, _qs, _qe = squat_optimizer
+        # Use the default initial guess (interpolated between start and end)
+        wp = opt._initial_guess()
+        x = wp.flatten()
+
+        class _FakeRes:
+            fun = 1.0
+            x = None
+
+        _FakeRes.x = x
+        result = opt._package_results(_FakeRes)
+        assert isinstance(result.n_joint_limit_violations, int)
+        assert result.n_joint_limit_violations >= 0
+
+    def test_violations_counted_when_q_exceeds_bounds(self, squat_optimizer) -> None:
+        """Forcing joint angles outside limits should produce a positive violation count."""
+        opt, _body, _dyn, _qs, _qe = squat_optimizer
+        # Build a waypoint array where all waypoints are set to a value well
+        # beyond the upper joint limit for every DOF.
+        n_wpt = opt.n_waypoints
+        n_dof = opt.dynamics.n_dof  # noqa: F841 (used via tile shape)
+        # Upper bound for each joint (grab from q_bounds)
+        upper = np.array([b[1] for b in opt.q_bounds])
+        # Set all waypoints to 2x the upper limit to guarantee violations
+        extreme_wp = np.tile(upper * 2.0, (n_wpt, 1))
+        x = extreme_wp.flatten()
+
+        class _FakeRes:
+            fun = 1.0
+            x = None
+
+        _FakeRes.x = x
+        result = opt._package_results(_FakeRes)
+        assert result.n_joint_limit_violations > 0


### PR DESCRIPTION
## Summary

- **CRITICAL**: Disable 3D Bilateral mode in GUI until implemented; add `NotImplementedError` catch in `_opt_worker` as safety net (issue #88)
- **CRITICAL**: Remove `sys.exit(0)` from `closeEvent` — Qt exits naturally after `event.accept()` (issue #89)
- **CRITICAL**: Add `body_override` parameter to `LagrangianDynamics.__init__` so `make_bench_press_config` can pass arm geometry cleanly without post-hoc private attribute surgery (issue #90)
- **HIGH**: Fix `MASS_FRAC` sum: `lower_legs` 0.093 → 0.094 so fractions sum to 1.000 (issue #91)
- **HIGH**: Fix `bar_position` for `clean`/`snatch`/`jerk` — each now returns the correct anatomical bar location instead of falling through to the default shoulder position (issue #92)
- **HIGH**: Add `n_joint_limit_violations: int` field to `OptimizationResult`; populated in `_package_results`; two new tests verify the field (issue #93)
- **MEDIUM**: Extract magic numbers `500.0`, `0.1`, `0.05` to `constants.py` as `BENCH_BAR_PATH_WEIGHT`, `TV_RATE_WEIGHT_RATIO`, `BAR_KNEE_CLEARANCE_M`; update all references in `trajectory.py` (issue #94)
- **MEDIUM**: Fix `comparison_metrics` to use trapezoidal rule instead of rectangle rule for `total_work` (issue #94)
- **MEDIUM**: Increase all Hypothesis `max_examples` from 10-50 to 100 (issue #94)
- **MEDIUM**: Tighten `test_mass_fractions_sum` tolerance from `< 1.0` to `< 0.01` (issue #94)

## Related Issues

Closes #88, #89, #90, #91, #92, #93, #94

## Test plan

- [ ] `ruff check src/ tests/` passes (confirmed clean)
- [ ] `ruff format src/ tests/` applied (1 file reformatted)
- [ ] All modified files pass Python 3.12 AST syntax check
- [ ] `TestJointLimitViolationTracking` two new tests verify `n_joint_limit_violations` field behaviour
- [ ] `test_mass_fractions_sum` now uses tight tolerance `< 0.01`
- [ ] All Hypothesis tests now use `max_examples=100`
- [ ] Full test suite: `PYTHONPATH=src python3 -m pytest tests/ -v`

Generated with [Claude Code](https://claude.com/claude-code)