### PR TITLE
Fix Hill force-velocity concentric/eccentric branch selection

### DIFF
--- a/src/movement_optimizer/strength.py
+++ b/src/movement_optimizer/strength.py
@@ -52,13 +52,31 @@ class HillTorqueModel:
         """Gaussian torque-angle scaling factor in [0, 1]."""
         return np.exp(-(((np.asarray(q) - self.q_optimal) / self.angle_width) ** 2))
 
-    def torque_velocity_factor(self, qd: float | NDArray) -> NDArray:
-        """Hill-type force-velocity scaling factor."""
+    def torque_velocity_factor(self, qd: float | NDArray, torque_sign: float = -1.0) -> NDArray:
+        """Hill-type force-velocity scaling factor.
+
+        Branch selection is based on whether the muscle is shortening
+        (concentric) or lengthening (eccentric).  The muscle shortens when
+        the angular velocity ``qd`` has the same sign as ``torque_sign``
+        (the direction in which the joint's prime movers produce torque).
+
+        Parameters:
+            qd: Joint angular velocity (rad/s).  Scalar or array.
+            torque_sign: Sign convention for the joint's primary torque
+                direction.  Default is -1.0 (flexor-dominant, e.g. elbow
+                curl produces negative qd).  Use +1.0 for extensor-dominant
+                joints.  When ``qd * torque_sign > 0`` the muscle is
+                shortening (concentric); otherwise it is lengthening
+                (eccentric).
+        """
         qd = np.asarray(qd)
         speed = np.abs(qd)
         conc = (self.v_max - speed) / (self.v_max + speed / self.k_shape)
         ecc = (1.0 + self.ecc_factor * speed) / (1.0 + speed / self.k_shape)
-        factor = np.where(conc > 0, conc, ecc)
+        # Concentric when the muscle is shortening: qd and torque_sign
+        # have the same sign.  Eccentric when lengthening (braking).
+        is_concentric = qd * torque_sign >= 0
+        factor = np.where(is_concentric, conc, ecc)
         return np.clip(factor, 0.0, self.max_ecc_ratio)
 
     def available_torque(self, q: float | NDArray, qd: float | NDArray) -> NDArray:

--- a/tests/test_joint_limits.py
+++ b/tests/test_joint_limits.py
@@ -141,20 +141,27 @@ class TestHillTorqueModel:
         np.testing.assert_allclose(f_vel, 1.0, atol=0.01)
 
     def test_concentric_decreases_with_speed(self) -> None:
-        """Faster concentric contraction should reduce available torque."""
+        """Faster concentric contraction should reduce available torque.
+
+        With default torque_sign=-1, negative qd = concentric (shortening).
+        """
         model = HillTorqueModel(tau_max=200.0, q_optimal=0.0)
-        t_slow = model.available_torque(0.0, 1.0)
-        t_fast = model.available_torque(0.0, 5.0)
+        # Negative qd → concentric; larger magnitude → less force
+        t_slow = model.available_torque(0.0, -1.0)
+        t_fast = model.available_torque(0.0, -5.0)
         assert t_slow > t_fast
 
     def test_eccentric_above_isometric(self) -> None:
-        """Eccentric loading (past v_max) should exceed concentric near-zero."""
+        """Eccentric factor should exceed concentric near v_max.
+
+        With default torque_sign=-1, positive qd = eccentric (lengthening).
+        """
         model = HillTorqueModel(tau_max=200.0, q_optimal=0.0)
-        # At v_max, concentric → 0.  Just past v_max, eccentric activates.
-        f_at_vmax = model.torque_velocity_factor(model.v_max - 0.01)
-        f_past_vmax = model.torque_velocity_factor(model.v_max + 0.5)
-        # Eccentric branch should give more than the near-zero concentric
-        assert f_past_vmax > f_at_vmax
+        # Concentric at high speed (near v_max) → near zero
+        f_conc_fast = model.torque_velocity_factor(-(model.v_max - 0.01))
+        # Eccentric at moderate speed → above isometric
+        f_ecc = model.torque_velocity_factor(2.0)
+        assert f_ecc > f_conc_fast
 
     def test_available_torque_always_nonneg(self) -> None:
         """Available torque should never be negative."""
@@ -183,17 +190,24 @@ class TestHillTorqueModel:
         assert f[1] > f[2]
 
     def test_batch_velocity_factor(self) -> None:
-        """Velocity factor should vectorize correctly."""
+        """Velocity factor should vectorize correctly.
+
+        With default torque_sign=-1, negative qd = concentric.
+        """
         model = HillTorqueModel(tau_max=200.0, q_optimal=0.0)
-        qd = np.array([0.0, 2.0, 8.0])
+        # Negative qd → concentric; increasing magnitude → decreasing factor
+        qd = np.array([0.0, -2.0, -8.0])
         f = model.torque_velocity_factor(qd)
         assert f.shape == (3,)
-        # Should decrease with increasing speed (concentric)
         assert f[0] >= f[1] >= f[2]
 
     def test_eccentric_capped(self) -> None:
-        """Eccentric factor should not exceed max_ecc_ratio."""
+        """Eccentric factor should not exceed max_ecc_ratio.
+
+        With default torque_sign=-1, positive qd = eccentric.
+        """
         model = HillTorqueModel(tau_max=200.0, q_optimal=0.0, max_ecc_ratio=1.4)
+        # Positive qd → eccentric at very high speed
         f = model.torque_velocity_factor(np.radians(10000))
         assert f <= 1.4 + 1e-10
 


### PR DESCRIPTION
## Summary
- The Hill force-velocity model selected concentric vs eccentric branches based on whether the concentric formula yielded a positive value (effectively a speed threshold at `v_max`), not on actual muscle shortening/lengthening direction
- Now uses `qd * torque_sign` to determine the branch: when angular velocity and torque direction have the same sign the muscle is shortening (concentric), otherwise lengthening (eccentric)
- Added `torque_sign` parameter to `torque_velocity_factor()` with default `-1.0` (flexor-dominant convention)

## Test plan
- [x] Updated `test_concentric_decreases_with_speed` to use negative qd (concentric with default torque_sign)
- [x] Updated `test_eccentric_above_isometric` to properly test eccentric vs concentric branches
- [x] Updated `test_batch_velocity_factor` and `test_eccentric_capped` for sign convention
- [x] All 157 relevant tests pass (2 pre-existing failures in bench press FK joint naming excluded)

Fixes #120

Generated with [Claude Code](https://claude.com/claude-code)