### PR TITLE
Fix bench press to use supine gravity direction

### DIFF
--- a/src/movement_optimizer/models.py
+++ b/src/movement_optimizer/models.py
@@ -263,6 +263,7 @@ class LagrangianDynamics(PhysicsBackend):
         I_segments: NDArray,
         load_mass: float,
         body_override: dict[str, NDArray] | None = None,
+        supine: bool = False,
     ) -> None:
         """Initialise Lagrangian dynamics for a 3-link planar chain.
 
@@ -276,6 +277,9 @@ class LagrangianDynamics(PhysicsBackend):
                 coupling-coefficient calculations.  Used by non-leg kinematic
                 chains (e.g. the arm chain for bench press) without resorting
                 to post-hoc attribute surgery.
+            supine: If True, gravity acts perpendicular to the chain axis
+                (the lifter is lying down).  Gravity torque uses cos(q)
+                instead of sin(q).  Used for bench press.
         """
         if len(m_segments) != 3:
             raise ValueError("need 3 segment masses")
@@ -286,6 +290,7 @@ class LagrangianDynamics(PhysicsBackend):
         self.I = I_segments
         self.m_load = load_mass
         self.g = body.g
+        self.supine = supine
 
         # Allow callers to supply alternative segment geometry (e.g. arm chain).
         if body_override is not None:
@@ -295,7 +300,9 @@ class LagrangianDynamics(PhysicsBackend):
             self.L_eff = L.copy()
             self.d = d
             self.d_eff = d.copy()
-            self.joint_names = body_override.get("joint_names", ["link0", "link1", "link2", "link3"])
+            self.joint_names = body_override.get(
+                "joint_names", ["link0", "link1", "link2", "link3"]
+            )
         else:
             self.L = body.L
             self.L_eff = body.L_eff
@@ -358,9 +365,10 @@ class LagrangianDynamics(PhysicsBackend):
 
     def _gravity_vector(self, q: NDArray) -> NDArray:
         G = np.zeros(3)
-        G[0] = self._g0 * np.sin(q[0])
-        G[1] = self._g1 * np.sin(q[1])
-        G[2] = self._g2 * np.sin(q[2])
+        trig = np.cos if self.supine else np.sin
+        G[0] = self._g0 * trig(q[0])
+        G[1] = self._g1 * trig(q[1])
+        G[2] = self._g2 * trig(q[2])
         return G
 
     def inverse_dynamics(self, q: NDArray, qd: NDArray, qdd: NDArray) -> NDArray:
@@ -398,7 +406,8 @@ class LagrangianDynamics(PhysicsBackend):
             )
 
         n = q.shape[0]
-        sq = np.sin(q)
+        # Supine (bench press): gravity perpendicular to chain → cos(q)
+        sq = np.cos(q) if self.supine else np.sin(q)
         d01 = q[:, 0] - q[:, 1]
         d02 = q[:, 0] - q[:, 2]
         d12 = q[:, 1] - q[:, 2]
@@ -721,6 +730,7 @@ def make_bench_press_config(
         bp.I.copy(),
         bar_mass,
         body_override={"L": bp.L, "d": bp.d},
+        supine=True,
     )
 
     # Start: lockout (arms straight up, perpendicular to supine body)

--- a/tests/test_bench_press.py
+++ b/tests/test_bench_press.py
@@ -7,6 +7,7 @@ import numpy as np
 from movement_optimizer.models import (
     BenchPressModel,
     BodyModel,
+    LagrangianDynamics,
     make_bench_press_config,
 )
 
@@ -92,3 +93,50 @@ class TestBenchPressConfig:
         """q_start should equal q_end (full rep returns to lockout)."""
         _dyn, qs, qe, _qb, _q_via = make_bench_press_config(default_body, 60.0)
         np.testing.assert_allclose(qs, qe, atol=1e-12)
+
+    def test_bench_supine_gravity(self, default_body: BodyModel) -> None:
+        """Bench press dynamics should use supine gravity (cos instead of sin).
+
+        At q=0 (lockout, arms straight up), gravity torque should be
+        maximal in supine (cos(0)=1) but zero in standing (sin(0)=0).
+        """
+        dyn, _qs, _qe, _qb, _q_via = make_bench_press_config(default_body, 60.0)
+        assert dyn.supine is True
+
+        q_lockout = np.zeros(3)
+        grav = dyn._gravity_vector(q_lockout)
+        # Supine: cos(0) = 1, so gravity torque is maximal at lockout
+        assert np.all(np.abs(grav) > 0), "Supine gravity should be nonzero at q=0"
+
+    def test_standing_vs_supine_gravity(self, default_body: BodyModel) -> None:
+        """Standing gravity uses sin(q), supine uses cos(q).
+
+        At q = pi/2, sin(pi/2) = 1, cos(pi/2) = 0, so the two should
+        give opposite extremes.
+        """
+        bp = BenchPressModel(default_body)
+        # Standing chain (supine=False)
+        dyn_standing = LagrangianDynamics(
+            default_body,
+            bp.m.copy(),
+            bp.I.copy(),
+            60.0,
+            body_override={"L": bp.L, "d": bp.d},
+            supine=False,
+        )
+        # Supine chain
+        dyn_supine = LagrangianDynamics(
+            default_body,
+            bp.m.copy(),
+            bp.I.copy(),
+            60.0,
+            body_override={"L": bp.L, "d": bp.d},
+            supine=True,
+        )
+
+        q_zero = np.zeros(3)
+        grav_standing = dyn_standing._gravity_vector(q_zero)
+        grav_supine = dyn_supine._gravity_vector(q_zero)
+        # At q=0: sin(0)=0, cos(0)=1
+        np.testing.assert_allclose(grav_standing, 0.0, atol=1e-12)
+        assert np.all(np.abs(grav_supine) > 0)


### PR DESCRIPTION
## Summary
- Bench press dynamics used standing gravity `G[i] = g_i * sin(q[i])`, but the lifter is supine so gravity acts perpendicular to the chain axis
- Added `supine` parameter to `LagrangianDynamics.__init__()` that switches gravity torque to `g_i * cos(q[i])` in both single-step and batch inverse dynamics
- `make_bench_press_config` now passes `supine=True`
- The COM/BOS constraint was already correctly disabled for bench press in the trajectory optimizer

## Test plan
- [x] Added `test_bench_supine_gravity` verifying `dyn.supine is True` and gravity is nonzero at lockout (q=0)
- [x] Added `test_standing_vs_supine_gravity` confirming standing gives zero gravity at q=0 while supine gives nonzero
- [x] All 151 relevant tests pass (2 pre-existing failures in FK joint naming excluded)

Fixes #122

Generated with [Claude Code](https://claude.com/claude-code)