### PR TITLE
feat: gait analyzer + sit-to-stand

### DIFF
--- a/src/movement_optimizer/exercises/__init__.py
+++ b/src/movement_optimizer/exercises/__init__.py
@@ -1,5 +1,8 @@
 """Exercise configuration factories."""
 
 from .clean import make_clean_config as make_clean_config
+from .gait import GaitAnalyzer as GaitAnalyzer
+from .gait import make_gait_config as make_gait_config
 from .jerk import make_jerk_config as make_jerk_config
+from .sit_to_stand import make_sit_to_stand_config as make_sit_to_stand_config
 from .snatch import make_snatch_config as make_snatch_config

--- a/src/movement_optimizer/exercises/gait.py
+++ b/src/movement_optimizer/exercises/gait.py
@@ -1,0 +1,138 @@
+"""Gait (walking) exercise configuration and analysis.
+
+Defines a full gait cycle from right heel strike to next right heel strike.
+Uses Winter (2009) normative joint angles for self-selected walking speed.
+
+Design Principles:
+    DBC -- public functions validate inputs.
+    DRY -- reuses the shared ``_common`` helpers and ``BodyModel`` API.
+    LoD -- callers interact only through the public factory + ``GaitAnalyzer``.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+
+import numpy as np
+from numpy.typing import NDArray
+
+from ..models import BodyModel, LagrangianDynamics
+
+logger = logging.getLogger(__name__)
+
+
+def _gait_via_points() -> list[tuple[float, float, float, float]]:
+    """Winter normative sagittal-plane angles for one gait cycle.
+
+    Convention: (fraction, ankle_angle, knee_angle, hip_angle) in radians.
+    Angles follow the repo convention: ankle-knee-hip from distal to proximal.
+    """
+    return [
+        # fraction  ankle              knee                hip
+        (0.00, math.radians(0), math.radians(-5), math.radians(30)),  # heel strike
+        (0.10, math.radians(-5), math.radians(-15), math.radians(25)),  # loading response
+        (0.30, math.radians(5), math.radians(-5), math.radians(0)),  # midstance
+        (0.50, math.radians(-15), math.radians(0), math.radians(-10)),  # terminal stance + push-off
+        (0.60, math.radians(5), math.radians(-40), math.radians(-5)),  # pre-swing
+        (0.70, math.radians(0), math.radians(-60), math.radians(15)),  # initial swing
+        (0.85, math.radians(0), math.radians(-30), math.radians(25)),  # mid swing
+        (1.00, math.radians(0), math.radians(-5), math.radians(30)),  # terminal swing = heel strike
+    ]
+
+
+def make_gait_config(
+    body: BodyModel,
+    stride_length: float = 0.7,
+    cycle_duration: float = 1.0,
+) -> tuple[LagrangianDynamics, NDArray, NDArray, NDArray, list[tuple[float, float, float, float]]]:
+    """Create gait cycle configuration.
+
+    Returns:
+        (dynamics, q_start, q_end, q_bounds, via_points)
+
+    Preconditions:
+        stride_length > 0
+        cycle_duration > 0
+    """
+    if stride_length <= 0:
+        raise ValueError("stride_length must be positive")
+    if cycle_duration <= 0:
+        raise ValueError("cycle_duration must be positive")
+
+    via_points = _gait_via_points()
+
+    # No external load during walking
+    dyn = LagrangianDynamics(body, body.m_squat.copy(), body.I_squat.copy(), 0.0)
+
+    q_start = np.array([via_points[0][1], via_points[0][2], via_points[0][3]])
+    q_end = np.array([via_points[-1][1], via_points[-1][2], via_points[-1][3]])
+
+    q_bounds = np.array(
+        [
+            [np.radians(-20), np.radians(20)],  # ankle
+            [np.radians(-65), np.radians(5)],  # knee
+            [np.radians(-15), np.radians(40)],  # hip
+        ]
+    )
+
+    return dyn, q_start, q_end, q_bounds, via_points
+
+
+class GaitAnalyzer:
+    """Analyze gait cycle kinematics and kinetics.
+
+    Computes:
+    - Spatiotemporal parameters (cadence, stride length, speed)
+    - Stance/swing phase timing
+    - Symmetry indices
+    """
+
+    def __init__(self, model: BodyModel) -> None:
+        if not isinstance(model, BodyModel):
+            raise TypeError("model must be a BodyModel instance")
+        self.model = model
+
+    def compute_spatiotemporal(
+        self, q: NDArray, t: NDArray, stride_length: float
+    ) -> dict[str, float]:
+        """Compute gait spatiotemporal parameters.
+
+        Preconditions:
+            q.ndim in (1, 2) and len(q) == len(t)
+            stride_length > 0
+        """
+        if stride_length <= 0:
+            raise ValueError("stride_length must be positive")
+        if len(t) < 2:
+            raise ValueError("need at least 2 time samples")
+
+        duration = float(t[-1] - t[0])
+        cadence = 60.0 / duration  # cycles / min
+        speed = stride_length / duration
+
+        # Estimate stance/swing from knee flexion
+        knee_angles = q[:, 1] if q.ndim > 1 else q
+        swing_mask = np.abs(knee_angles) > math.radians(20)
+        stance_pct = 1.0 - float(np.mean(swing_mask))
+
+        return {
+            "cadence_steps_per_min": cadence * 2,
+            "stride_length_m": stride_length,
+            "walking_speed_m_s": speed,
+            "stance_phase_pct": stance_pct * 100,
+            "swing_phase_pct": (1 - stance_pct) * 100,
+            "cycle_duration_s": duration,
+        }
+
+    def compute_symmetry_index(self, left_angles: NDArray, right_angles: NDArray) -> float:
+        """Robinson symmetry index: SI = |L-R| / max(L,R) * 100.
+
+        Preconditions:
+            left_angles and right_angles are 1-D arrays of the same length.
+        """
+        l_range = float(np.ptp(left_angles))
+        r_range = float(np.ptp(right_angles))
+        if max(l_range, r_range) < 1e-10:
+            return 0.0
+        return abs(l_range - r_range) / max(l_range, r_range) * 100

--- a/src/movement_optimizer/exercises/sit_to_stand.py
+++ b/src/movement_optimizer/exercises/sit_to_stand.py
@@ -1,0 +1,83 @@
+"""Sit-to-stand exercise configuration.
+
+Phases: seated -> forward lean (momentum) -> seat-off -> rising -> standing.
+The torso forward lean is critical for generating momentum to leave the chair.
+
+Design Principles:
+    DBC -- factory validates inputs.
+    DRY -- reuses BodyModel and LagrangianDynamics.
+    LoD -- callers get a standard config tuple.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+
+import numpy as np
+from numpy.typing import NDArray
+
+from ..models import BodyModel, LagrangianDynamics
+
+logger = logging.getLogger(__name__)
+
+
+def _sts_via_points(q_start: NDArray, q_end: NDArray) -> list[tuple[float, float, float, float]]:
+    """Via-points for sit-to-stand motion."""
+    return [
+        (0.00, float(q_start[0]), float(q_start[1]), float(q_start[2])),  # seated
+        (0.20, math.radians(15), math.radians(-90), math.radians(100)),  # forward lean
+        (0.35, math.radians(20), math.radians(-85), math.radians(90)),  # max lean + seat off
+        (0.50, math.radians(15), math.radians(-60), math.radians(60)),  # rising phase 1
+        (0.75, math.radians(5), math.radians(-30), math.radians(30)),  # rising phase 2
+        (1.00, float(q_end[0]), float(q_end[1]), float(q_end[2])),  # standing
+    ]
+
+
+def make_sit_to_stand_config(
+    body: BodyModel,
+    seat_height: float = 0.45,
+) -> tuple[LagrangianDynamics, NDArray, NDArray, NDArray, list[tuple[float, float, float, float]]]:
+    """Create sit-to-stand configuration.
+
+    Returns:
+        (dynamics, q_start, q_end, q_bounds, via_points)
+
+    Preconditions:
+        seat_height > 0
+    """
+    if seat_height <= 0:
+        raise ValueError("seat_height must be positive")
+
+    # Seated angles: ankle dorsiflexion, knee ~90 deg flexion, hip ~80 deg flexion
+    q_start = np.array(
+        [
+            math.radians(10),  # ankle: slight dorsiflexion
+            math.radians(-90),  # knee: ~90 deg flexion (seated)
+            math.radians(80),  # hip: ~80 deg flexion (seated)
+        ]
+    )
+
+    # Standing: near neutral
+    q_end = np.array(
+        [
+            math.radians(0),  # ankle: neutral
+            math.radians(0),  # knee: straight
+            math.radians(0),  # hip: upright
+        ]
+    )
+
+    via_points = _sts_via_points(q_start, q_end)
+
+    # No external load
+    dyn = LagrangianDynamics(body, body.m_squat.copy(), body.I_squat.copy(), 0.0)
+
+    q_bounds = np.array(
+        [
+            [np.radians(-5), np.radians(25)],  # ankle
+            [np.radians(-95), np.radians(5)],  # knee
+            [np.radians(-5), np.radians(110)],  # hip (allows forward lean)
+        ]
+    )
+
+    return dyn, q_start, q_end, q_bounds, via_points

--- a/src/movement_optimizer/models.py
+++ b/src/movement_optimizer/models.py
@@ -55,6 +55,8 @@ __all__ = [
     "make_deadlift_config",
     "make_default_torque_set",
     "make_full_squat_config",
+    "make_gait_config",
+    "make_sit_to_stand_config",
     "make_squat_config",
 ]
 
@@ -805,3 +807,10 @@ def make_bench_press_config(
     )
 
     return dyn, q_start, q_end, q_bounds, q_via
+
+
+# Re-export exercise factories added in the exercises subpackage
+from .exercises.gait import make_gait_config as make_gait_config  # noqa: E402
+from .exercises.sit_to_stand import (  # noqa: E402
+    make_sit_to_stand_config as make_sit_to_stand_config,
+)

--- a/tests/test_gait_sts.py
+++ b/tests/test_gait_sts.py
@@ -1,0 +1,154 @@
+"""Tests for gait and sit-to-stand exercise configurations."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from movement_optimizer.exercises import GaitAnalyzer, make_gait_config, make_sit_to_stand_config
+from movement_optimizer.models import BodyModel, LagrangianDynamics
+
+
+@pytest.fixture()
+def default_body() -> BodyModel:
+    return BodyModel(75.0, 1.75)
+
+
+# ------------------------------------------------------------------
+# Gait config
+# ------------------------------------------------------------------
+
+
+class TestGaitConfig:
+    def test_gait_config_returns_valid_tuple(self, default_body: BodyModel) -> None:
+        dyn, qs, qe, qb, via = make_gait_config(default_body)
+        assert isinstance(dyn, LagrangianDynamics)
+        assert qs.shape == (3,)
+        assert qe.shape == (3,)
+        assert qb.shape == (3, 2)
+        assert isinstance(via, list)
+
+    def test_gait_is_cyclic(self, default_body: BodyModel) -> None:
+        """Start and end angles should be identical (full cycle)."""
+        _dyn, qs, qe, _qb, _via = make_gait_config(default_body)
+        np.testing.assert_allclose(qs, qe, atol=1e-10)
+
+    def test_gait_has_8_phases(self, default_body: BodyModel) -> None:
+        _dyn, _qs, _qe, _qb, via = make_gait_config(default_body)
+        assert len(via) == 8
+
+    def test_gait_via_fractions_span_0_to_1(self, default_body: BodyModel) -> None:
+        _dyn, _qs, _qe, _qb, via = make_gait_config(default_body)
+        assert via[0][0] == 0.0
+        assert via[-1][0] == 1.0
+
+    def test_gait_zero_load(self, default_body: BodyModel) -> None:
+        dyn, _qs, _qe, _qb, _via = make_gait_config(default_body)
+        assert dyn.m_load == 0.0
+
+    def test_gait_rejects_bad_stride(self, default_body: BodyModel) -> None:
+        with pytest.raises(ValueError, match="stride_length"):
+            make_gait_config(default_body, stride_length=-1.0)
+
+    def test_gait_rejects_bad_duration(self, default_body: BodyModel) -> None:
+        with pytest.raises(ValueError, match="cycle_duration"):
+            make_gait_config(default_body, cycle_duration=0.0)
+
+
+# ------------------------------------------------------------------
+# GaitAnalyzer
+# ------------------------------------------------------------------
+
+
+class TestGaitAnalyzer:
+    def test_spatiotemporal_basic(self, default_body: BodyModel) -> None:
+        analyzer = GaitAnalyzer(default_body)
+        t = np.linspace(0, 1.0, 100)
+        # Simulate knee angles varying through swing
+        knee = np.where(t > 0.6, math.radians(-40), math.radians(-10))
+        q = np.column_stack([np.zeros(100), knee, np.zeros(100)])
+        result = analyzer.compute_spatiotemporal(q, t, stride_length=0.7)
+        assert result["stride_length_m"] == 0.7
+        assert result["walking_speed_m_s"] == pytest.approx(0.7, rel=1e-6)
+        assert result["cycle_duration_s"] == pytest.approx(1.0, rel=1e-6)
+        assert 0.0 < result["stance_phase_pct"] < 100.0
+        assert result["stance_phase_pct"] + result["swing_phase_pct"] == pytest.approx(100.0)
+
+    def test_symmetry_index_identical(self, default_body: BodyModel) -> None:
+        analyzer = GaitAnalyzer(default_body)
+        angles = np.linspace(-0.5, 0.5, 50)
+        si = analyzer.compute_symmetry_index(angles, angles)
+        assert si == pytest.approx(0.0)
+
+    def test_symmetry_index_asymmetric(self, default_body: BodyModel) -> None:
+        analyzer = GaitAnalyzer(default_body)
+        left = np.linspace(0, 1.0, 50)
+        right = np.linspace(0, 0.5, 50)
+        si = analyzer.compute_symmetry_index(left, right)
+        assert si > 0.0
+        assert si == pytest.approx(50.0, rel=1e-6)
+
+    def test_symmetry_index_zero_range(self, default_body: BodyModel) -> None:
+        analyzer = GaitAnalyzer(default_body)
+        constant = np.ones(10) * 0.5
+        si = analyzer.compute_symmetry_index(constant, constant)
+        assert si == 0.0
+
+    def test_rejects_bad_model(self) -> None:
+        with pytest.raises(TypeError):
+            GaitAnalyzer("not a model")  # type: ignore[arg-type]
+
+    def test_spatiotemporal_rejects_bad_stride(self, default_body: BodyModel) -> None:
+        analyzer = GaitAnalyzer(default_body)
+        with pytest.raises(ValueError, match="stride_length"):
+            analyzer.compute_spatiotemporal(np.zeros(10), np.linspace(0, 1, 10), -1.0)
+
+
+# ------------------------------------------------------------------
+# Sit-to-stand config
+# ------------------------------------------------------------------
+
+
+class TestSitToStandConfig:
+    def test_sts_config_returns_valid_tuple(self, default_body: BodyModel) -> None:
+        dyn, qs, qe, qb, via = make_sit_to_stand_config(default_body)
+        assert isinstance(dyn, LagrangianDynamics)
+        assert qs.shape == (3,)
+        assert qe.shape == (3,)
+        assert qb.shape == (3, 2)
+        assert isinstance(via, list)
+
+    def test_sts_seated_to_standing(self, default_body: BodyModel) -> None:
+        """Start should be seated (large flexion), end near upright."""
+        _dyn, qs, qe, _qb, _via = make_sit_to_stand_config(default_body)
+        # Seated: knee should be heavily flexed
+        assert qs[1] < math.radians(-60)
+        # Standing: knee should be near zero
+        assert abs(qe[1]) < math.radians(10)
+
+    def test_sts_has_6_phases(self, default_body: BodyModel) -> None:
+        _dyn, _qs, _qe, _qb, via = make_sit_to_stand_config(default_body)
+        assert len(via) == 6
+
+    def test_sts_via_fractions_span_0_to_1(self, default_body: BodyModel) -> None:
+        _dyn, _qs, _qe, _qb, via = make_sit_to_stand_config(default_body)
+        assert via[0][0] == 0.0
+        assert via[-1][0] == 1.0
+
+    def test_sts_zero_load(self, default_body: BodyModel) -> None:
+        dyn, _qs, _qe, _qb, _via = make_sit_to_stand_config(default_body)
+        assert dyn.m_load == 0.0
+
+    def test_sts_rejects_bad_seat_height(self, default_body: BodyModel) -> None:
+        with pytest.raises(ValueError, match="seat_height"):
+            make_sit_to_stand_config(default_body, seat_height=0.0)
+
+    def test_sts_forward_lean_phase(self, default_body: BodyModel) -> None:
+        """The forward lean phase should have hip angle > start hip angle."""
+        _dyn, _qs, _qe, _qb, via = make_sit_to_stand_config(default_body)
+        # via[1] is forward lean; hip is index 3
+        lean_hip = via[1][3]
+        start_hip = via[0][3]
+        assert lean_hip > start_hip, "Forward lean should increase hip flexion"


### PR DESCRIPTION
## Summary
- Adds gait cycle analysis with Winter (2009) normative joint angles, spatiotemporal parameter computation (cadence, stride length, speed, stance/swing %), and Robinson symmetry index
- Adds sit-to-stand exercise configuration with forward lean momentum generation phases (seated -> lean -> seat-off -> rising -> standing)
- Both exercises use zero external load and follow the existing tuple-return convention (dynamics, q_start, q_end, q_bounds, via_points)
- 20 new tests covering config validity, phase counts, cyclic gait, seated-to-standing transitions, input validation, and analyzer computations

## Test plan
- [x] All 246 tests pass (`pytest tests/ -x`)
- [x] `ruff check` clean
- [x] `ruff format` clean
- [x] Gait config: valid tuple, cyclic (start == end), 8 phases, zero load, input validation
- [x] GaitAnalyzer: spatiotemporal params, symmetry index (identical/asymmetric/zero-range), bad input rejection
- [x] Sit-to-stand config: valid tuple, seated->standing angles, 6 phases, zero load, forward lean phase, input validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)