### PR TITLE
fix: extract squat/standing pose angles into named constants

### DIFF
--- a/src/movement_optimizer/constants.py
+++ b/src/movement_optimizer/constants.py
@@ -87,6 +87,20 @@ JOINT_LIMITS: dict[str, tuple[float, float]] = {
 JOINT_NAMES: tuple[str, ...] = ("ankle", "knee", "hip")
 
 # ------------------------------------------------------------------
+# Canonical exercise poses (degrees)
+#
+# These define the raw (pre-balance) joint angles for key positions.
+# Factory functions in models.py feed these into balance_pose() to
+# obtain the final COM-balanced configuration.
+# ------------------------------------------------------------------
+
+# Squat bottom: deep knee bend with moderate ankle & hip flexion.
+SQUAT_BOTTOM_DEG: tuple[float, float, float] = (25.0, -90.0, 50.0)
+
+# Standing: anatomically neutral upright (all joints at zero).
+STANDING_DEG: tuple[float, float, float] = (0.0, 0.0, 0.0)
+
+# ------------------------------------------------------------------
 # Default maximum isometric joint torques (N·m)
 #
 # Representative values for an average adult male.  These are the

--- a/src/movement_optimizer/models.py
+++ b/src/movement_optimizer/models.py
@@ -28,6 +28,8 @@ from .constants import (
     LENGTH_FRAC,
     MASS_FRAC,
     RADIUS_OF_GYRATION_FRAC,
+    SQUAT_BOTTOM_DEG,
+    STANDING_DEG,
     WRIST_SEGMENT_LENGTH,
 )
 from .strength import (
@@ -634,7 +636,7 @@ def _standing_balanced(dyn: LagrangianDynamics, bar_mass: float, exercise_type: 
 
     Adjusts shin angle (joint 0) to shift COM forward over mid-foot.
     """
-    q_stand = np.array([0.0, 0.0, 0.0])
+    q_stand = np.array([np.radians(a) for a in STANDING_DEG])
     return balance_pose(dyn, q_stand, exercise_type, bar_mass, adjust_joint=0)
 
 
@@ -643,7 +645,7 @@ def make_squat_config(
 ) -> tuple[LagrangianDynamics, NDArray, NDArray, NDArray]:
     dyn = LagrangianDynamics(body, body.m_squat.copy(), body.I_squat.copy(), bar_mass)
     # Squat bottom: deep knee bend, torso adjusted for COM balance
-    q_bottom_raw = np.array([np.radians(25), np.radians(-90), np.radians(50)])
+    q_bottom_raw = np.array([np.radians(a) for a in SQUAT_BOTTOM_DEG])
     q_start = balance_pose(dyn, q_bottom_raw, "squat", bar_mass, adjust_joint=2)
     q_end = _standing_balanced(dyn, bar_mass, "squat")
     q_bounds = np.array(
@@ -663,7 +665,7 @@ def make_full_squat_config(
     q_stand = _standing_balanced(dyn, bar_mass, "full_squat")
     q_start = q_stand.copy()
     q_end = q_stand.copy()
-    q_bottom_raw = np.array([np.radians(25), np.radians(-90), np.radians(50)])
+    q_bottom_raw = np.array([np.radians(a) for a in SQUAT_BOTTOM_DEG])
     q_via = balance_pose(dyn, q_bottom_raw, "full_squat", bar_mass, adjust_joint=2)
     q_bounds = np.array(
         [


### PR DESCRIPTION
## Summary
- Adds `SQUAT_BOTTOM_DEG` and `STANDING_DEG` constants to `constants.py` for the canonical squat-bottom and standing joint angles
- Replaces hardcoded `[25, -90, 50]` values in `make_squat_config` and `make_full_squat_config` with references to the new constants
- Replaces hardcoded `[0.0, 0.0, 0.0]` in `_standing_balanced` with a reference to `STANDING_DEG`

Closes #138

## Test plan
- [x] All 264 existing tests pass
- [x] Ruff lint passes with no warnings
- [x] Verified constants are referenced in both factory functions and `_standing_balanced`

🤖 Generated with [Claude Code](https://claude.com/claude-code)