### PR TITLE
fix: remove dead-code trapezoid None check

### DIFF
--- a/src/movement_optimizer/gui/main_window.py
+++ b/src/movement_optimizer/gui/main_window.py
@@ -578,8 +578,6 @@ class MainWindow(QMainWindow):
         self, name: str, r: OptimizationResult, exercise_type: str = "squat"
     ) -> None:
         pk = np.max(np.abs(r.torques), axis=0)
-        if trapezoid is None:
-            raise ValueError("DbC Blocked: Precondition failed.")
         work = trapezoid(np.sum(np.abs(r.power), axis=1), r.t)
 
         if exercise_type == "bench_press":


### PR DESCRIPTION
## Summary
- Removed the unreachable `if trapezoid is None` guard clause in `MainWindow._update_result_summary()` (`main_window.py`)
- The `trapezoid` function is validated at import time in `constants.py` (raises `ImportError` if neither `np.trapezoid` nor `np.trapz` exist), so it can never be `None` at runtime
- All 264 tests pass before and after the change

## Test plan
- [x] Verified all 264 tests pass before the change (baseline)
- [x] Removed the dead code (2 lines)
- [x] Verified all 264 tests pass after the change
- [x] Confirmed `constants.py` import-time validation makes the check unreachable

Closes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)