### PR TITLE
fix: refactor body_override, DRY optimizer, scale wrist length

### DIFF
--- a/src/movement_optimizer/constants.py
+++ b/src/movement_optimizer/constants.py
@@ -181,9 +181,11 @@ HILL_MAX_ECCENTRIC_RATIO: float = 1.4
 #
 # Segment fractions for the arm chain (fraction of arm length):
 # ------------------------------------------------------------------
-# Wrist/hand segment length [m] — effectively a grip-only link with
-# negligible lever arm. Used in the bench press 3-link model.
-WRIST_SEGMENT_LENGTH: float = 0.01
+# Wrist/hand segment length as a fraction of arm length.  Replaces the
+# former fixed 0.01 m constant so the link scales allometrically with
+# the lifter's body height (via arm_len).  ~1% of arm length yields
+# ~7 mm for a 1.75 m person — effectively a grip-only link.
+WRIST_SEGMENT_FRAC: float = 0.01
 
 BENCH_UPPER_ARM_FRAC: float = 0.56  # shoulder to elbow (anatomical ~48% + shoulder width)
 BENCH_FOREARM_FRAC: float = 0.44  # elbow to wrist (Winter 2009: ~44% of arm length)

--- a/src/movement_optimizer/models.py
+++ b/src/movement_optimizer/models.py
@@ -11,6 +11,7 @@ Design Principles:
 
 from __future__ import annotations
 
+import dataclasses
 import logging
 
 import numpy as np
@@ -30,7 +31,7 @@ from .constants import (
     RADIUS_OF_GYRATION_FRAC,
     SQUAT_BOTTOM_DEG,
     STANDING_DEG,
-    WRIST_SEGMENT_LENGTH,
+    WRIST_SEGMENT_FRAC,
 )
 from .strength import (
     HillTorqueModel,
@@ -44,6 +45,7 @@ logger = logging.getLogger(__name__)
 
 __all__ = [
     "BodyModel",
+    "ChainGeometry",
     "HillTorqueModel",
     "JointTorqueSet",
     "LagrangianDynamics",
@@ -60,6 +62,28 @@ __all__ = [
     "make_sit_to_stand_config",
     "make_squat_config",
 ]
+
+
+@dataclasses.dataclass(frozen=True)
+class ChainGeometry:
+    """Explicit geometry for a non-default kinematic chain.
+
+    Used to configure LagrangianDynamics for chains other than the default
+    leg model (e.g. the arm chain for bench press).  Replaces the old
+    dict-based ``body_override`` parameter with a typed, self-documenting
+    structure.
+
+    Attributes:
+        L: Segment lengths (length-3 array).
+        d: Segment COM distances from proximal joint (length-3 array).
+        joint_names: Human-readable names for the 3 joints + tip.
+    """
+
+    L: NDArray
+    d: NDArray
+    joint_names: list[str] = dataclasses.field(
+        default_factory=lambda: ["link0", "link1", "link2", "link3"]
+    )
 
 
 class BodyModel:
@@ -283,7 +307,7 @@ class LagrangianDynamics(PhysicsBackend):
         m_segments: NDArray,
         I_segments: NDArray,
         load_mass: float,
-        body_override: dict[str, NDArray] | None = None,
+        chain_geometry: ChainGeometry | None = None,
         supine: bool = False,
     ) -> None:
         """Initialise Lagrangian dynamics for a 3-link planar chain.
@@ -293,11 +317,9 @@ class LagrangianDynamics(PhysicsBackend):
             m_segments: Length-3 array of segment masses (kg).
             I_segments: Length-3 array of segment moments of inertia (kg·m²).
             load_mass: Mass of the external load at the chain tip (kg).
-            body_override: Optional dict with keys 'L', 'd' containing
-                length-3 NDArrays that override the body geometry for the
-                coupling-coefficient calculations.  Used by non-leg kinematic
-                chains (e.g. the arm chain for bench press) without resorting
-                to post-hoc attribute surgery.
+            chain_geometry: Optional ChainGeometry providing segment lengths,
+                COM distances, and joint names for non-leg kinematic chains
+                (e.g. the arm chain for bench press).
             supine: If True, gravity acts perpendicular to the chain axis
                 (the lifter is lying down).  Gravity torque uses cos(q)
                 instead of sin(q).  Used for bench press.
@@ -314,16 +336,14 @@ class LagrangianDynamics(PhysicsBackend):
         self.supine = supine
 
         # Allow callers to supply alternative segment geometry (e.g. arm chain).
-        if body_override is not None:
-            L = body_override["L"]
-            d = body_override["d"]
+        if chain_geometry is not None:
+            L = chain_geometry.L
+            d = chain_geometry.d
             self.L = L
             self.L_eff = L.copy()
             self.d = d
             self.d_eff = d.copy()
-            self.joint_names = body_override.get(
-                "joint_names", ["link0", "link1", "link2", "link3"]
-            )
+            self.joint_names = list(chain_geometry.joint_names)
         else:
             self.L = body.L
             self.L_eff = body.L_eff
@@ -718,7 +738,7 @@ class BenchPressModel:
             [
                 BENCH_UPPER_ARM_FRAC * arm_len,
                 BENCH_FOREARM_FRAC * arm_len,
-                WRIST_SEGMENT_LENGTH,  # wrist/hand (effectively zero — grip only)
+                WRIST_SEGMENT_FRAC * arm_len,  # wrist/hand — scales with body height
             ]
         )
         self.body_mass = body.body_mass
@@ -769,18 +789,18 @@ def make_bench_press_config(
     bp = BenchPressModel(body)
 
     # Create a dynamics object using arm segment properties.
-    # Pass body_override so the constructor uses arm geometry (L, d) for all
+    # ChainGeometry provides typed arm geometry (L, d) for all
     # coupling-coefficient calculations — no post-hoc attribute surgery needed.
     dyn = LagrangianDynamics(
         body,
         bp.m.copy(),
         bp.I.copy(),
         bar_mass,
-        body_override={
-            "L": bp.L,
-            "d": bp.d,
-            "joint_names": ["shoulder", "elbow", "wrist", "hand"],
-        },
+        chain_geometry=ChainGeometry(
+            L=bp.L,
+            d=bp.d,
+            joint_names=["shoulder", "elbow", "wrist", "hand"],
+        ),
         supine=True,
     )
 

--- a/src/movement_optimizer/trajectory/optimizer.py
+++ b/src/movement_optimizer/trajectory/optimizer.py
@@ -431,6 +431,34 @@ class TrajectoryOptimizer:
                 )
         return constraints
 
+    def _minimize_single(
+        self,
+        x0: NDArray,
+        cost_fn: Callable[[NDArray], float],
+        max_iter: int = MAX_ITER_PER_START,
+    ) -> object:
+        """Run one SLSQP solve — shared setup for both start paths.
+
+        Parameters:
+            x0: Flattened initial waypoint guess.
+            cost_fn: Objective function (may include eval counting).
+            max_iter: Maximum iterations for the solver.
+
+        Returns:
+            The scipy OptimizeResult object.
+        """
+        bounds = self._build_bounds()
+        constraints = self._build_constraints()
+        return minimize(
+            cost_fn,
+            x0,
+            method="SLSQP",
+            bounds=bounds,
+            constraints=constraints,
+            callback=self._cancel_callback,
+            options={"maxiter": max_iter, "ftol": 1e-6, "disp": False},
+        )
+
     def _run_single_start(self, seed: int) -> tuple[object, int] | None:
         """Run one SLSQP solve with a perturbed initial guess.
 
@@ -440,8 +468,6 @@ class TrajectoryOptimizer:
             return None
 
         wp0 = self._perturbed_guess(seed)
-        bounds = self._build_bounds()
-        constraints = self._build_constraints()
         eval_count = [0]
 
         def cost_fn(x: NDArray) -> float:
@@ -451,15 +477,7 @@ class TrajectoryOptimizer:
             return self._compute_cost(x)
 
         try:
-            res = minimize(
-                cost_fn,
-                wp0.flatten(),
-                method="SLSQP",
-                bounds=bounds,
-                constraints=constraints,
-                callback=self._cancel_callback,
-                options={"maxiter": MAX_ITER_PER_START, "ftol": 1e-6, "disp": False},
-            )
+            res = self._minimize_single(wp0.flatten(), cost_fn)
         except CancelledError:
             return None
 
@@ -559,23 +577,7 @@ class TrajectoryOptimizer:
         self._best_cost = float("inf")
 
         wp0 = self._initial_guess()
-        bounds = self._build_bounds()
-        constraints = self._build_constraints()
-
-        try:
-            res = minimize(
-                self.cost,
-                wp0.flatten(),
-                method="SLSQP",
-                bounds=bounds,
-                constraints=constraints,
-                callback=self._cancel_callback,
-                options={"maxiter": MAX_ITER_PER_START * 2, "ftol": 1e-6, "disp": False},
-            )
-        except CancelledError:
-            raise
-
-        return res
+        return self._minimize_single(wp0.flatten(), self.cost, max_iter=MAX_ITER_PER_START * 2)
 
     # ==========================================================
     # Result packaging

--- a/tests/test_bench_press.py
+++ b/tests/test_bench_press.py
@@ -7,6 +7,7 @@ import numpy as np
 from movement_optimizer.models import (
     BenchPressModel,
     BodyModel,
+    ChainGeometry,
     LagrangianDynamics,
     make_bench_press_config,
 )
@@ -120,7 +121,7 @@ class TestBenchPressConfig:
             bp.m.copy(),
             bp.I.copy(),
             60.0,
-            body_override={"L": bp.L, "d": bp.d},
+            chain_geometry=ChainGeometry(L=bp.L, d=bp.d),
             supine=False,
         )
         # Supine chain
@@ -129,7 +130,7 @@ class TestBenchPressConfig:
             bp.m.copy(),
             bp.I.copy(),
             60.0,
-            body_override={"L": bp.L, "d": bp.d},
+            chain_geometry=ChainGeometry(L=bp.L, d=bp.d),
             supine=True,
         )
 


### PR DESCRIPTION
## Summary
- **#112**: Replace dict-based `body_override` parameter with a frozen `ChainGeometry` dataclass — typed, self-documenting, and IDE-friendly. The old untyped dict required callers to know the magic keys `"L"`, `"d"`, `"joint_names"`.
- **#111**: Extract shared `minimize()` setup (method, bounds, constraints, options) into `_minimize_single()` helper. Both `_run_single_start` and `_run_single_start_with_progress` now delegate to it, eliminating the duplicated SLSQP configuration block.
- **#139**: Replace fixed `WRIST_SEGMENT_LENGTH = 0.01` m with `WRIST_SEGMENT_FRAC = 0.01` (1% of arm length), so the wrist link scales allometrically with the lifter's body height.

Closes #111, #112, #139

## Test plan
- [x] All 265 tests pass locally
- [x] `ruff check` and `ruff format` clean
- [ ] CI passes (quality-gate + tests matrix + rust)

🤖 Generated with [Claude Code](https://claude.com/claude-code)