### PR TITLE
Reduce complexity: LagrangianDynamics, MainWindow, bench press renderer

### DIFF
--- a/src/movement_optimizer/gui/animation_control.py
+++ b/src/movement_optimizer/gui/animation_control.py
@@ -1,0 +1,117 @@
+"""Animation playback helpers extracted from MainWindow.
+
+Provides play/pause toggle, step forward/back, rewind, and frame
+advance as a mixin class.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .main_window import MainWindow
+
+
+class AnimationControlMixin:
+    """Mixin providing animation playback for MainWindow."""
+
+    def _toggle_play(self: MainWindow) -> None:  # type: ignore[override]
+        idx = self.tabs.currentIndex()
+        if self.results[idx] is None:
+            return
+        if self.is_playing:
+            self._stop_anim()
+        else:
+            self.is_playing = True
+            self.controls.set_playing(True)
+            self._anim_step()
+
+    def _stop_anim(self: MainWindow) -> None:  # type: ignore[override]
+        self.is_playing = False
+        self.anim_timer.stop()
+        self.controls.set_playing(False)
+
+    def _anim_step(self: MainWindow) -> None:  # type: ignore[override]
+        if not self.is_playing:
+            return
+        idx = self.tabs.currentIndex()
+        r = self.results[idx]
+        if r is None:
+            return
+
+        fi = self.anim_frames[idx]
+        _, etype = self.EXERCISE_CONFIGS[idx]
+        body = self.bodies_list[idx]
+        if body is None:
+            raise ValueError("DbC Blocked: Precondition failed.")
+        self.exercise_tabs[idx].draw_anim_frame(
+            fi,
+            r,
+            self.dynamics_list[idx],
+            body,
+            etype,
+        )
+
+        n = len(r.t)
+        self.anim_frames[idx] = (fi + 1) % n
+        self.controls.frame_label.setText(f"Frame {fi + 1}/{n}")
+
+        speed = self.controls.speed_slider.value() / 10.0
+        delay = max(15, int(40 / max(0.1, speed)))
+        if self.anim_frames[idx] == 0:
+            delay = 700
+        self.anim_timer.start(delay)
+
+    def _step_fwd(self: MainWindow) -> None:  # type: ignore[override]
+        idx = self.tabs.currentIndex()
+        r = self.results[idx]
+        if r is None:
+            return
+        self._stop_anim()
+        n = len(r.t)
+        self.anim_frames[idx] = (self.anim_frames[idx] + 1) % n
+        _, etype = self.EXERCISE_CONFIGS[idx]
+        self.exercise_tabs[idx].draw_anim_frame(
+            self.anim_frames[idx],
+            r,
+            self.dynamics_list[idx],
+            self.bodies_list[idx],  # type: ignore[arg-type]
+            etype,
+        )
+        self.controls.frame_label.setText(f"Frame {self.anim_frames[idx] + 1}/{n}")
+
+    def _step_back(self: MainWindow) -> None:  # type: ignore[override]
+        idx = self.tabs.currentIndex()
+        r = self.results[idx]
+        if r is None:
+            return
+        self._stop_anim()
+        n = len(r.t)
+        self.anim_frames[idx] = (self.anim_frames[idx] - 1) % n
+        _, etype = self.EXERCISE_CONFIGS[idx]
+        self.exercise_tabs[idx].draw_anim_frame(
+            self.anim_frames[idx],
+            r,
+            self.dynamics_list[idx],
+            self.bodies_list[idx],  # type: ignore[arg-type]
+            etype,
+        )
+
+    def _rewind(self: MainWindow) -> None:  # type: ignore[override]
+        idx = self.tabs.currentIndex()
+        r = self.results[idx]
+        if r is None:
+            return
+        self._stop_anim()
+        self.anim_frames[idx] = 0
+        _, etype = self.EXERCISE_CONFIGS[idx]
+        self.exercise_tabs[idx].draw_anim_frame(
+            0,
+            r,
+            self.dynamics_list[idx],
+            self.bodies_list[idx],  # type: ignore[arg-type]
+            etype,
+        )
+
+    def _on_speed(self: MainWindow, speed: float) -> None:  # type: ignore[override]
+        self.controls.speed_label.setText(f"{speed:.1f}x")

--- a/src/movement_optimizer/gui/comparison_mixin.py
+++ b/src/movement_optimizer/gui/comparison_mixin.py
@@ -1,0 +1,49 @@
+"""Comparison trial helpers extracted from MainWindow.
+
+Provides add/compare/clear trial comparison actions as a mixin class.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from PyQt6.QtWidgets import QMessageBox
+
+from .comparison_dialog import ComparisonDialog
+
+if TYPE_CHECKING:
+    from .main_window import MainWindow
+
+
+class ComparisonMixin:
+    """Mixin providing trial comparison actions for MainWindow."""
+
+    def _add_comparison(self: MainWindow) -> None:  # type: ignore[override]
+        idx = self.tabs.currentIndex()
+        r = self.results[idx]
+        if r is None:
+            return
+        display_name, _etype = self.EXERCISE_CONFIGS[idx]
+        bar = self.sidebar.bar_slider.value()
+        body_params = {
+            "body_mass": self.sidebar.mass_slider.value(),
+            "height": self.sidebar.height_slider.value(),
+        }
+        n = len(self._comparison_store.get_trials()) + 1
+        trial_name = f"{display_name} #{n} ({bar:.0f}kg)"
+        self._comparison_store.add_trial(trial_name, r, body_params, bar)
+        self.sidebar.compare_btn.setEnabled(True)
+        self.status_label.setText(f"Added '{trial_name}' to comparison list.")
+
+    def _compare_trials(self: MainWindow) -> None:  # type: ignore[override]
+        trials = self._comparison_store.get_trials()
+        if not trials:
+            QMessageBox.information(self, "No Trials", "Add trials to compare first.")
+            return
+        dlg = ComparisonDialog(trials, self)
+        dlg.exec()
+
+    def _clear_comparison(self: MainWindow) -> None:  # type: ignore[override]
+        self._comparison_store.clear()
+        self.sidebar.compare_btn.setEnabled(False)
+        self.status_label.setText("Comparison list cleared.")

--- a/src/movement_optimizer/gui/exercise_tab.py
+++ b/src/movement_optimizer/gui/exercise_tab.py
@@ -356,6 +356,13 @@ class ExerciseTab(QWidget):
 
         self.canvas.draw()
 
+    # -- Bench press rendering constants ----------------------------
+    _BENCH_HEIGHT = 0.45
+    _BENCH_HEAD_X = -0.40
+    _BENCH_NECK_X = -0.30
+    _BENCH_SHOULDER_X = -0.18
+    _BENCH_HIP_X = 0.30
+
     def _draw_bench_press_frame(
         self,
         ax: Any,
@@ -366,28 +373,32 @@ class ExerciseTab(QWidget):
         fk: dict[str, Any],
     ) -> None:
         """Render bench press: supine body on bench with arm chain."""
-        from matplotlib.patches import Circle as MplCircle
-
         ax.set_xlim(-0.6, 0.8)
         ax.set_ylim(-0.15, 1.4)
         ax.set_aspect("equal", adjustable="datalim")
 
-        bench_h = 0.45
+        self._draw_bench_and_body(ax)
+        hand_pos, arm_base, fk_origin = self._draw_bench_arm_chain(ax, fk)
+        self._draw_bench_barbell_and_trace(ax, fi, result, hand_pos, arm_base, fk_origin)
+        self._draw_bench_title(ax, q, t_now)
 
-        # Draw bench
-        ax.fill_between([-0.8, 0.5], bench_h - 0.05, bench_h, color="#8B4513", alpha=0.6)
+    def _draw_bench_and_body(self, ax: Any) -> None:
+        """Draw the bench surface, supine body (decorative), and ground line."""
+        from matplotlib.patches import Circle as MplCircle
 
-        # Draw body lying on bench (decorative -- not part of dynamics)
-        # Shoulder is near the head end (top of torso), not mid-body
-        head_x, head_y = -0.40, bench_h + 0.05
-        neck_x = -0.30
-        shoulder_x = -0.18
-        hip_x = 0.30
+        bh = self._BENCH_HEIGHT
+        head_x = self._BENCH_HEAD_X
+        neck_x = self._BENCH_NECK_X
+        shoulder_x = self._BENCH_SHOULDER_X
+        hip_x = self._BENCH_HIP_X
+
+        # Bench surface
+        ax.fill_between([-0.8, 0.5], bh - 0.05, bh, color="#8B4513", alpha=0.6)
 
         # Neck
         ax.plot(
             [head_x + 0.08, neck_x],
-            [bench_h + 0.05, bench_h + 0.02],
+            [bh + 0.05, bh + 0.02],
             "-",
             color="#d4a574",
             lw=5,
@@ -396,7 +407,7 @@ class ExerciseTab(QWidget):
         # Head
         ax.add_patch(
             MplCircle(
-                (head_x, head_y),
+                (head_x, bh + 0.05),
                 0.08,
                 facecolor="#d4a574",
                 edgecolor="#333",
@@ -406,26 +417,19 @@ class ExerciseTab(QWidget):
             )
         )
         # Torso (horizontal on bench)
-        ax.plot(
-            [neck_x, shoulder_x],
-            [bench_h + 0.02, bench_h + 0.02],
-            "-",
-            color=Palette.SEG_COLORS[2],
-            lw=12,
-            solid_capstyle="round",
-        )
-        ax.plot(
-            [shoulder_x, hip_x],
-            [bench_h + 0.02, bench_h + 0.02],
-            "-",
-            color=Palette.SEG_COLORS[2],
-            lw=12,
-            solid_capstyle="round",
-        )
+        for x0, x1 in [(neck_x, shoulder_x), (shoulder_x, hip_x)]:
+            ax.plot(
+                [x0, x1],
+                [bh + 0.02, bh + 0.02],
+                "-",
+                color=Palette.SEG_COLORS[2],
+                lw=12,
+                solid_capstyle="round",
+            )
         # Legs hanging off bench to floor
         ax.plot(
             [hip_x, hip_x + 0.15],
-            [bench_h, 0],
+            [bh, 0],
             "-",
             color=Palette.SEG_COLORS[1],
             lw=9,
@@ -439,18 +443,22 @@ class ExerciseTab(QWidget):
             lw=6,
             solid_capstyle="round",
         )
-
         # Ground line
         ax.plot([-0.6, 0.8], [0, 0], color=Palette.FG_DIM, lw=2, alpha=0.3)
 
-        # Arm chain from FK (the actual dynamics)
-        # FK "ankle" = shoulder joint position, remap to bench shoulder position
-        arm_base = np.array([shoulder_x, bench_h + 0.02])
+    def _draw_bench_arm_chain(self, ax: Any, fk: dict[str, Any]) -> tuple[Any, Any, Any]:
+        """Draw the arm kinematic chain.
+
+        Returns (hand_position, arm_base, fk_origin) for barbell placement.
+        """
+        bh = self._BENCH_HEIGHT
+        shoulder_x = self._BENCH_SHOULDER_X
+
+        arm_base = np.array([shoulder_x, bh + 0.02])
         fk_points = [fk["ankle"], fk["knee"], fk["hip"], fk["shoulder"]]
-        # Offset FK relative to arm_base (FK has ankle at origin)
         arm_joints = [arm_base + (pt - fk_points[0]) for pt in fk_points]
 
-        # Draw arm segments: upper arm, forearm, hand/wrist
+        # Arm segments: upper arm, forearm, hand/wrist
         colors = [Palette.SEG_COLORS[0], Palette.SEG_COLORS[1], "#b0b0b0"]
         lws = [8, 6, 4]
         for k in range(3):
@@ -462,7 +470,6 @@ class ExerciseTab(QWidget):
                 lw=lws[k],
                 solid_capstyle="round",
             )
-
         # Joint markers
         for pt in arm_joints:
             ax.plot(
@@ -474,16 +481,26 @@ class ExerciseTab(QWidget):
                 markeredgecolor="#333",
                 markeredgewidth=1,
             )
+        return arm_joints[-1], arm_base, fk_points[0]
 
-        # Bar at hand position (end of chain)
-        bar_pos = arm_joints[-1]
-        BarbellRenderer.draw(ax, (bar_pos[0], bar_pos[1]))
+    def _draw_bench_barbell_and_trace(
+        self,
+        ax: Any,
+        fi: int,
+        result: OptimizationResult,
+        hand_pos: Any,
+        arm_base: Any,
+        fk_origin: Any,
+    ) -> None:
+        """Draw the barbell at hand position and the bar path trace."""
+        BarbellRenderer.draw(ax, (hand_pos[0], hand_pos[1]))
 
-        # Bar trace — offset the FK-based trace to bench coordinates
-        bar_trace_offset = arm_base - fk_points[0]
+        bar_trace_offset = arm_base - fk_origin
         bench_bar_traj = result.bar + bar_trace_offset
         BodyRenderer.draw_bar_trace(ax, bench_bar_traj, fi)
 
+    def _draw_bench_title(self, ax: Any, q: Any, t_now: float) -> None:
+        """Set the bench press animation title with joint angles."""
         ax.set_title(
             f"{self.name}  t={t_now:.2f}s  |  "
             f"Shoulder {np.degrees(q[0]):.0f}\u00b0  "

--- a/src/movement_optimizer/gui/file_operations.py
+++ b/src/movement_optimizer/gui/file_operations.py
@@ -1,0 +1,206 @@
+"""File I/O helpers extracted from MainWindow.
+
+Provides CSV export, solution save/load, GIF export, and plot export
+as a mixin class so MainWindow stays focused on layout and coordination.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import logging
+import os
+from typing import TYPE_CHECKING, Any
+
+from PyQt6.QtWidgets import QFileDialog, QMessageBox
+
+from ..export import export_animation_gif, export_plots_pdf, export_plots_png
+from ..persistence import load_solution, save_solution
+from ..trajectory import OptimizationResult
+
+if TYPE_CHECKING:
+    from .main_window import MainWindow
+
+logger = logging.getLogger(__name__)
+
+
+class FileOperationsMixin:
+    """Mixin providing file I/O actions for MainWindow."""
+
+    def _export(self: MainWindow) -> None:  # type: ignore[override]
+        idx = self.tabs.currentIndex()
+        r = self.results[idx]
+        if r is None:
+            return
+        name = self.EXERCISE_CONFIGS[idx][0].lower().replace(" ", "_")
+        path, _ = QFileDialog.getSaveFileName(
+            self,
+            "Export CSV",
+            f"{name}_trajectory.csv",
+            "CSV Files (*.csv)",
+        )
+        if not path:
+            return
+        _write_csv(self, path, r)
+
+    def _save_solution(self: MainWindow) -> None:  # type: ignore[override]
+        idx = self.tabs.currentIndex()
+        r = self.results[idx]
+        if r is None:
+            return
+        name = self.EXERCISE_CONFIGS[idx][0].lower().replace(" ", "_")
+        path, _ = QFileDialog.getSaveFileName(
+            self,
+            "Save Solution",
+            f"{name}_solution.json",
+            "JSON Files (*.json)",
+        )
+        if not path:
+            return
+        try:
+            body_params = {
+                "body_mass": self.sidebar.mass_slider.value(),
+                "height": self.sidebar.height_slider.value(),
+                "seg_multipliers": {
+                    "lower_leg": self.sidebar.ll_slider.value(),
+                    "upper_leg": self.sidebar.ul_slider.value(),
+                    "torso": self.sidebar.to_slider.value(),
+                },
+            }
+            _, etype = self.EXERCISE_CONFIGS[idx]
+            bar = self.sidebar.bar_slider.value()
+            save_solution(path, r, body_params, etype, bar)
+            self.status_label.setText(f"Saved: {os.path.basename(path)}")
+        except (OSError, TypeError, ValueError) as e:
+            QMessageBox.critical(self, "Save Error", str(e))
+
+    def _load_solution(self: MainWindow) -> None:  # type: ignore[override]
+        path, _ = QFileDialog.getOpenFileName(
+            self,
+            "Load Solution",
+            "",
+            "JSON Files (*.json)",
+        )
+        if not path:
+            return
+        try:
+            data = load_solution(path)
+            self.status_label.setText(
+                f"Loaded solution: {data.get('exercise_type', 'unknown')} "
+                f"from {os.path.basename(path)}"
+            )
+            QMessageBox.information(
+                self,
+                "Solution Loaded",
+                f"Exercise: {data.get('exercise_type')}\n"
+                f"Bar mass: {data.get('bar_mass')} kg\n"
+                f"Cost: {data.get('metadata', {}).get('cost', 'N/A')}",
+            )
+        except (OSError, json.JSONDecodeError, KeyError, ValueError) as e:
+            QMessageBox.critical(self, "Load Error", str(e))
+
+    def _export_video(self: MainWindow) -> None:  # type: ignore[override]
+        idx = self.tabs.currentIndex()
+        r = self.results[idx]
+        if r is None:
+            return
+        name = self.EXERCISE_CONFIGS[idx][0].lower().replace(" ", "_")
+        path, _ = QFileDialog.getSaveFileName(
+            self,
+            "Export Animation GIF",
+            f"{name}_animation.gif",
+            "GIF Files (*.gif)",
+        )
+        if not path:
+            return
+        try:
+            tab = self.exercise_tabs[idx]
+            _, etype = self.EXERCISE_CONFIGS[idx]
+            body = self.bodies_list[idx]
+            dyn = self.dynamics_list[idx]
+            n_frames = len(r.t)
+
+            if body is None:
+                raise ValueError("DbC Blocked: Precondition failed.")
+
+            def draw_frame(fi: int) -> None:
+                tab.draw_anim_frame(fi, r, dyn, body, etype)
+
+            export_animation_gif(tab.fig, draw_frame, n_frames, path, fps=15)
+            self.status_label.setText(f"Exported GIF: {os.path.basename(path)}")
+            QMessageBox.information(self, "Exported", f"Animation saved to:\n{path}")
+        except (OSError, ValueError, RuntimeError) as e:
+            QMessageBox.critical(self, "Export Error", str(e))
+
+    def _export_plots(self: MainWindow) -> None:  # type: ignore[override]
+        idx = self.tabs.currentIndex()
+        r = self.results[idx]
+        if r is None:
+            return
+        name = self.EXERCISE_CONFIGS[idx][0].lower().replace(" ", "_")
+        path, _selected_filter = QFileDialog.getSaveFileName(
+            self,
+            "Export Plots",
+            f"{name}_plots.png",
+            "PNG Files (*.png);;PDF Files (*.pdf)",
+        )
+        if not path:
+            return
+        try:
+            tab = self.exercise_tabs[idx]
+            if path.lower().endswith(".pdf"):
+                export_plots_pdf(tab.fig, path)
+            else:
+                export_plots_png(tab.fig, path)
+            self.status_label.setText(f"Exported: {os.path.basename(path)}")
+            QMessageBox.information(self, "Exported", f"Plots saved to:\n{path}")
+        except (OSError, ValueError, RuntimeError) as e:
+            QMessageBox.critical(self, "Export Error", str(e))
+
+
+def _write_csv(win: Any, path: str, r: OptimizationResult) -> None:
+    """Write trajectory data to a CSV file."""
+    import numpy as np
+
+    try:
+        with open(path, "w", newline="", encoding="utf-8") as f:
+            w = csv.writer(f)
+            w.writerow(
+                [
+                    "time_s",
+                    "shin_angle_deg",
+                    "thigh_angle_deg",
+                    "torso_angle_deg",
+                    "shin_vel_deg_s",
+                    "thigh_vel_deg_s",
+                    "torso_vel_deg_s",
+                    "ankle_torque_Nm",
+                    "knee_torque_Nm",
+                    "hip_torque_Nm",
+                    "ankle_power_W",
+                    "knee_power_W",
+                    "hip_power_W",
+                    "com_x_m",
+                    "com_y_m",
+                    "bar_x_m",
+                    "bar_y_m",
+                ]
+            )
+            for i in range(len(r.t)):
+                w.writerow(
+                    [
+                        f"{r.t[i]:.4f}",
+                        *[f"{np.degrees(r.q[i, j]):.2f}" for j in range(3)],
+                        *[f"{np.degrees(r.qd[i, j]):.2f}" for j in range(3)],
+                        *[f"{r.torques[i, j]:.2f}" for j in range(3)],
+                        *[f"{r.power[i, j]:.2f}" for j in range(3)],
+                        f"{r.com[i, 0]:.4f}",
+                        f"{r.com[i, 1]:.4f}",
+                        f"{r.bar[i, 0]:.4f}",
+                        f"{r.bar[i, 1]:.4f}",
+                    ]
+                )
+        win.status_label.setText(f"Exported: {os.path.basename(path)}")
+        QMessageBox.information(win, "Exported", f"Saved to:\n{path}")
+    except (OSError, ValueError) as e:
+        QMessageBox.critical(win, "Export Error", str(e))

--- a/src/movement_optimizer/gui/main_window.py
+++ b/src/movement_optimizer/gui/main_window.py
@@ -15,10 +15,7 @@ Design Principles:
 
 from __future__ import annotations
 
-import csv
-import json
 import logging
-import os
 import threading
 import traceback
 from collections.abc import Callable
@@ -28,7 +25,6 @@ import matplotlib
 import numpy as np
 from PyQt6.QtCore import QSettings, Qt, QTimer, pyqtSignal
 from PyQt6.QtWidgets import (
-    QFileDialog,
     QLabel,
     QMainWindow,
     QMessageBox,
@@ -41,9 +37,8 @@ from PyQt6.QtWidgets import (
 from ..cli import EXERCISE_FACTORIES
 from ..comparison import ComparisonStore
 from ..constants import trapezoid
-from ..export import export_animation_gif, export_plots_pdf, export_plots_png
 from ..models import BodyModel
-from ..persistence import load_app_state, load_solution, save_app_state, save_solution
+from ..persistence import load_app_state, save_app_state
 from ..rendering import (
     Palette,
 )
@@ -54,8 +49,10 @@ from ..trajectory import (
     SolutionCache,
     TrajectoryOptimizer,
 )
-from .comparison_dialog import ComparisonDialog
+from .animation_control import AnimationControlMixin
+from .comparison_mixin import ComparisonMixin
 from .exercise_tab import ExerciseTab
+from .file_operations import FileOperationsMixin
 from .session_state import collect_results, collect_slider_values, restore_slider_values
 from .widgets import ParameterSidebar, PlaybackControls
 
@@ -209,8 +206,13 @@ QScrollArea {{
 # ==============================================================
 
 
-class MainWindow(QMainWindow):
-    """Top-level application window."""
+class MainWindow(FileOperationsMixin, AnimationControlMixin, ComparisonMixin, QMainWindow):
+    """Top-level application window.
+
+    File I/O, animation playback, and comparison actions are provided
+    by mixin classes in ``file_operations``, ``animation_control``, and
+    ``comparison_mixin`` respectively.
+    """
 
     # Signals for thread-safe GUI updates from the optimizer worker.
     # Using signals instead of QTimer.singleShot is the Qt-correct way
@@ -604,310 +606,10 @@ class MainWindow(QMainWindow):
         self.status_label.setText(f"Error: {msg}")
         QMessageBox.critical(self, "Error", msg)
 
-    def _toggle_play(self) -> None:
-        idx = self.tabs.currentIndex()
-        if self.results[idx] is None:
-            return
-        if self.is_playing:
-            self._stop_anim()
-        else:
-            self.is_playing = True
-            self.controls.set_playing(True)
-            self._anim_step()
-
-    def _stop_anim(self) -> None:
-        self.is_playing = False
-        self.anim_timer.stop()
-        self.controls.set_playing(False)
-
-    def _anim_step(self) -> None:
-        if not self.is_playing:
-            return
-        idx = self.tabs.currentIndex()
-        r = self.results[idx]
-        if r is None:
-            return
-
-        fi = self.anim_frames[idx]
-        _, etype = self.EXERCISE_CONFIGS[idx]
-        body = self.bodies_list[idx]
-        if body is None:
-            raise ValueError("DbC Blocked: Precondition failed.")
-        self.exercise_tabs[idx].draw_anim_frame(
-            fi,
-            r,
-            self.dynamics_list[idx],
-            body,
-            etype,
-        )
-
-        n = len(r.t)
-        self.anim_frames[idx] = (fi + 1) % n
-        self.controls.frame_label.setText(f"Frame {fi + 1}/{n}")
-
-        speed = self.controls.speed_slider.value() / 10.0
-        delay = max(15, int(40 / max(0.1, speed)))
-        if self.anim_frames[idx] == 0:
-            delay = 700
-        self.anim_timer.start(delay)
-
-    def _step_fwd(self) -> None:
-        idx = self.tabs.currentIndex()
-        r = self.results[idx]
-        if r is None:
-            return
-        self._stop_anim()
-        n = len(r.t)
-        self.anim_frames[idx] = (self.anim_frames[idx] + 1) % n
-        _, etype = self.EXERCISE_CONFIGS[idx]
-        self.exercise_tabs[idx].draw_anim_frame(
-            self.anim_frames[idx],
-            r,
-            self.dynamics_list[idx],
-            self.bodies_list[idx],  # type: ignore[arg-type]
-            etype,
-        )
-        self.controls.frame_label.setText(f"Frame {self.anim_frames[idx] + 1}/{n}")
-
-    def _step_back(self) -> None:
-        idx = self.tabs.currentIndex()
-        r = self.results[idx]
-        if r is None:
-            return
-        self._stop_anim()
-        n = len(r.t)
-        self.anim_frames[idx] = (self.anim_frames[idx] - 1) % n
-        _, etype = self.EXERCISE_CONFIGS[idx]
-        self.exercise_tabs[idx].draw_anim_frame(
-            self.anim_frames[idx],
-            r,
-            self.dynamics_list[idx],
-            self.bodies_list[idx],  # type: ignore[arg-type]
-            etype,
-        )
-
-    def _rewind(self) -> None:
-        idx = self.tabs.currentIndex()
-        r = self.results[idx]
-        if r is None:
-            return
-        self._stop_anim()
-        self.anim_frames[idx] = 0
-        _, etype = self.EXERCISE_CONFIGS[idx]
-        self.exercise_tabs[idx].draw_anim_frame(
-            0,
-            r,
-            self.dynamics_list[idx],
-            self.bodies_list[idx],  # type: ignore[arg-type]
-            etype,
-        )
-
-    def _on_speed(self, speed: float) -> None:
-        self.controls.speed_label.setText(f"{speed:.1f}x")
-
-    def _export(self) -> None:
-        idx = self.tabs.currentIndex()
-        r = self.results[idx]
-        if r is None:
-            return
-        name = self.EXERCISE_CONFIGS[idx][0].lower().replace(" ", "_")
-        path, _ = QFileDialog.getSaveFileName(
-            self,
-            "Export CSV",
-            f"{name}_trajectory.csv",
-            "CSV Files (*.csv)",
-        )
-        if not path:
-            return
-        self._write_csv(path, r)
-
-    def _write_csv(self, path: str, r: OptimizationResult) -> None:
-        try:
-            with open(path, "w", newline="", encoding="utf-8") as f:
-                w = csv.writer(f)
-                w.writerow(
-                    [
-                        "time_s",
-                        "shin_angle_deg",
-                        "thigh_angle_deg",
-                        "torso_angle_deg",
-                        "shin_vel_deg_s",
-                        "thigh_vel_deg_s",
-                        "torso_vel_deg_s",
-                        "ankle_torque_Nm",
-                        "knee_torque_Nm",
-                        "hip_torque_Nm",
-                        "ankle_power_W",
-                        "knee_power_W",
-                        "hip_power_W",
-                        "com_x_m",
-                        "com_y_m",
-                        "bar_x_m",
-                        "bar_y_m",
-                    ]
-                )
-                for i in range(len(r.t)):
-                    w.writerow(
-                        [
-                            f"{r.t[i]:.4f}",
-                            *[f"{np.degrees(r.q[i, j]):.2f}" for j in range(3)],
-                            *[f"{np.degrees(r.qd[i, j]):.2f}" for j in range(3)],
-                            *[f"{r.torques[i, j]:.2f}" for j in range(3)],
-                            *[f"{r.power[i, j]:.2f}" for j in range(3)],
-                            f"{r.com[i, 0]:.4f}",
-                            f"{r.com[i, 1]:.4f}",
-                            f"{r.bar[i, 0]:.4f}",
-                            f"{r.bar[i, 1]:.4f}",
-                        ]
-                    )
-            self.status_label.setText(f"Exported: {os.path.basename(path)}")
-            QMessageBox.information(self, "Exported", f"Saved to:\n{path}")
-        except (OSError, ValueError) as e:
-            QMessageBox.critical(self, "Export Error", str(e))
-
-    def _save_solution(self) -> None:
-        idx = self.tabs.currentIndex()
-        r = self.results[idx]
-        if r is None:
-            return
-        name = self.EXERCISE_CONFIGS[idx][0].lower().replace(" ", "_")
-        path, _ = QFileDialog.getSaveFileName(
-            self,
-            "Save Solution",
-            f"{name}_solution.json",
-            "JSON Files (*.json)",
-        )
-        if not path:
-            return
-        try:
-            body_params = {
-                "body_mass": self.sidebar.mass_slider.value(),
-                "height": self.sidebar.height_slider.value(),
-                "seg_multipliers": {
-                    "lower_leg": self.sidebar.ll_slider.value(),
-                    "upper_leg": self.sidebar.ul_slider.value(),
-                    "torso": self.sidebar.to_slider.value(),
-                },
-            }
-            _, etype = self.EXERCISE_CONFIGS[idx]
-            bar = self.sidebar.bar_slider.value()
-            save_solution(path, r, body_params, etype, bar)
-            self.status_label.setText(f"Saved: {os.path.basename(path)}")
-        except (OSError, TypeError, ValueError) as e:
-            QMessageBox.critical(self, "Save Error", str(e))
-
-    def _load_solution(self) -> None:
-        path, _ = QFileDialog.getOpenFileName(
-            self,
-            "Load Solution",
-            "",
-            "JSON Files (*.json)",
-        )
-        if not path:
-            return
-        try:
-            data = load_solution(path)
-            self.status_label.setText(
-                f"Loaded solution: {data.get('exercise_type', 'unknown')} "
-                f"from {os.path.basename(path)}"
-            )
-            QMessageBox.information(
-                self,
-                "Solution Loaded",
-                f"Exercise: {data.get('exercise_type')}\n"
-                f"Bar mass: {data.get('bar_mass')} kg\n"
-                f"Cost: {data.get('metadata', {}).get('cost', 'N/A')}",
-            )
-        except (OSError, json.JSONDecodeError, KeyError, ValueError) as e:
-            QMessageBox.critical(self, "Load Error", str(e))
-
-    def _export_video(self) -> None:
-        idx = self.tabs.currentIndex()
-        r = self.results[idx]
-        if r is None:
-            return
-        name = self.EXERCISE_CONFIGS[idx][0].lower().replace(" ", "_")
-        path, _ = QFileDialog.getSaveFileName(
-            self,
-            "Export Animation GIF",
-            f"{name}_animation.gif",
-            "GIF Files (*.gif)",
-        )
-        if not path:
-            return
-        try:
-            tab = self.exercise_tabs[idx]
-            _, etype = self.EXERCISE_CONFIGS[idx]
-            body = self.bodies_list[idx]
-            dyn = self.dynamics_list[idx]
-            n_frames = len(r.t)
-
-            if body is None:
-                raise ValueError("DbC Blocked: Precondition failed.")
-
-            def draw_frame(fi: int) -> None:
-                tab.draw_anim_frame(fi, r, dyn, body, etype)
-
-            export_animation_gif(tab.fig, draw_frame, n_frames, path, fps=15)
-            self.status_label.setText(f"Exported GIF: {os.path.basename(path)}")
-            QMessageBox.information(self, "Exported", f"Animation saved to:\n{path}")
-        except (OSError, ValueError, RuntimeError) as e:
-            QMessageBox.critical(self, "Export Error", str(e))
-
-    def _export_plots(self) -> None:
-        idx = self.tabs.currentIndex()
-        r = self.results[idx]
-        if r is None:
-            return
-        name = self.EXERCISE_CONFIGS[idx][0].lower().replace(" ", "_")
-        path, _selected_filter = QFileDialog.getSaveFileName(
-            self,
-            "Export Plots",
-            f"{name}_plots.png",
-            "PNG Files (*.png);;PDF Files (*.pdf)",
-        )
-        if not path:
-            return
-        try:
-            tab = self.exercise_tabs[idx]
-            if path.lower().endswith(".pdf"):
-                export_plots_pdf(tab.fig, path)
-            else:
-                export_plots_png(tab.fig, path)
-            self.status_label.setText(f"Exported: {os.path.basename(path)}")
-            QMessageBox.information(self, "Exported", f"Plots saved to:\n{path}")
-        except (OSError, ValueError, RuntimeError) as e:
-            QMessageBox.critical(self, "Export Error", str(e))
-
-    def _add_comparison(self) -> None:
-        idx = self.tabs.currentIndex()
-        r = self.results[idx]
-        if r is None:
-            return
-        display_name, _etype = self.EXERCISE_CONFIGS[idx]
-        bar = self.sidebar.bar_slider.value()
-        body_params = {
-            "body_mass": self.sidebar.mass_slider.value(),
-            "height": self.sidebar.height_slider.value(),
-        }
-        n = len(self._comparison_store.get_trials()) + 1
-        trial_name = f"{display_name} #{n} ({bar:.0f}kg)"
-        self._comparison_store.add_trial(trial_name, r, body_params, bar)
-        self.sidebar.compare_btn.setEnabled(True)
-        self.status_label.setText(f"Added '{trial_name}' to comparison list.")
-
-    def _compare_trials(self) -> None:
-        trials = self._comparison_store.get_trials()
-        if not trials:
-            QMessageBox.information(self, "No Trials", "Add trials to compare first.")
-            return
-        dlg = ComparisonDialog(trials, self)
-        dlg.exec()
-
-    def _clear_comparison(self) -> None:
-        self._comparison_store.clear()
-        self.sidebar.compare_btn.setEnabled(False)
-        self.status_label.setText("Comparison list cleared.")
+    # Animation, file I/O, and comparison methods are provided by the
+    # mixin classes: AnimationControlMixin, FileOperationsMixin, and
+    # ComparisonMixin.  See animation_control.py, file_operations.py,
+    # and comparison_mixin.py.
 
     def _reset(self) -> None:
         self._stop_anim()

--- a/src/movement_optimizer/models.py
+++ b/src/movement_optimizer/models.py
@@ -335,7 +335,22 @@ class LagrangianDynamics(PhysicsBackend):
         self.g = body.g
         self.supine = supine
 
-        # Allow callers to supply alternative segment geometry (e.g. arm chain).
+        L, d = self._init_chain_geometry(body, chain_geometry)
+        self._init_coupling_coefficients(m_segments, load_mass, L, d)
+        self._init_diagonal_mass_constants(m_segments, I_segments, load_mass, L, d)
+        self._init_gravity_coefficients(body.g, m_segments, load_mass, L, d)
+
+    # -- init helpers -----------------------------------------------
+
+    def _init_chain_geometry(
+        self,
+        body: BodyModel,
+        chain_geometry: ChainGeometry | None,
+    ) -> tuple[NDArray, NDArray]:
+        """Set segment lengths, COM distances, and joint names.
+
+        Returns the (L, d) arrays used by subsequent coefficient setup.
+        """
         if chain_geometry is not None:
             L = chain_geometry.L
             d = chain_geometry.d
@@ -352,29 +367,45 @@ class LagrangianDynamics(PhysicsBackend):
             self.joint_names = ["ankle", "knee", "hip", "shoulder"]
             L = body.L
             d = body.d
+        return L, d
 
-        # Pre-compute coupling coefficients (constant for given model)
-        self._a01 = (m_segments[1] * d[1] + (m_segments[2] + load_mass) * L[1]) * L[0]
-        self._a02 = (m_segments[2] * d[2] + load_mass * L[2]) * L[0]
-        self._a12 = (m_segments[2] * d[2] + load_mass * L[2]) * L[1]
+    def _init_coupling_coefficients(
+        self,
+        m: NDArray,
+        m_load: float,
+        L: NDArray,
+        d: NDArray,
+    ) -> None:
+        """Pre-compute off-diagonal coupling coefficients (constant for a given model)."""
+        self._a01 = (m[1] * d[1] + (m[2] + m_load) * L[1]) * L[0]
+        self._a02 = (m[2] * d[2] + m_load * L[2]) * L[0]
+        self._a12 = (m[2] * d[2] + m_load * L[2]) * L[1]
 
-        # Diagonal mass-matrix constants
-        self._M00 = (
-            m_segments[0] * d[0] ** 2
-            + (m_segments[1] + m_segments[2] + load_mass) * L[0] ** 2
-            + I_segments[0]
-        )
-        self._M11 = (
-            m_segments[1] * d[1] ** 2 + (m_segments[2] + load_mass) * L[1] ** 2 + I_segments[1]
-        )
-        self._M22 = m_segments[2] * d[2] ** 2 + load_mass * L[2] ** 2 + I_segments[2]
+    def _init_diagonal_mass_constants(
+        self,
+        m: NDArray,
+        inertia: NDArray,
+        m_load: float,
+        L: NDArray,
+        d: NDArray,
+    ) -> None:
+        """Pre-compute diagonal mass-matrix constants."""
+        self._M00 = m[0] * d[0] ** 2 + (m[1] + m[2] + m_load) * L[0] ** 2 + inertia[0]
+        self._M11 = m[1] * d[1] ** 2 + (m[2] + m_load) * L[1] ** 2 + inertia[1]
+        self._M22 = m[2] * d[2] ** 2 + m_load * L[2] ** 2 + inertia[2]
 
-        # Gravity coefficients
-        self._g0 = body.g * (
-            m_segments[0] * d[0] + (m_segments[1] + m_segments[2] + load_mass) * L[0]
-        )
-        self._g1 = body.g * (m_segments[1] * d[1] + (m_segments[2] + load_mass) * L[1])
-        self._g2 = body.g * (m_segments[2] * d[2] + load_mass * L[2])
+    def _init_gravity_coefficients(
+        self,
+        g: float,
+        m: NDArray,
+        m_load: float,
+        L: NDArray,
+        d: NDArray,
+    ) -> None:
+        """Pre-compute gravity torque coefficients."""
+        self._g0 = g * (m[0] * d[0] + (m[1] + m[2] + m_load) * L[0])
+        self._g1 = g * (m[1] * d[1] + (m[2] + m_load) * L[1])
+        self._g2 = g * (m[2] * d[2] + m_load * L[2])
 
     @property
     def n_dof(self) -> int:


### PR DESCRIPTION
## Summary

- **#174** -- Extract `LagrangianDynamics.__init__` (74 lines) into 4 focused helpers: `_init_chain_geometry`, `_init_coupling_coefficients`, `_init_diagonal_mass_constants`, `_init_gravity_coefficients`
- **#173** -- Decompose `MainWindow` (916 -> 618 lines) into 3 mixin modules: `FileOperationsMixin` (file I/O, CSV/JSON/GIF/plot export), `AnimationControlMixin` (play/pause/step/rewind), `ComparisonMixin` (trial comparison actions)
- **#172** -- Break `_draw_bench_press_frame` (137 lines) into 4 composable drawing steps: `_draw_bench_and_body`, `_draw_bench_arm_chain`, `_draw_bench_barbell_and_trace`, `_draw_bench_title`

No .github/workflows/ files were modified.

Closes #172, closes #173, closes #174

## Test plan

- [x] All 265 tests pass
- [x] ruff check passes on all changed files
- [x] ruff format passes on all changed files
- [ ] Verify GUI launches and bench press animation renders correctly
- [ ] Verify file export (CSV, JSON, GIF, PNG/PDF) still works
- [ ] Verify comparison dialog still works

Generated with Claude Code