### PR TITLE
refactor: decompose bench press drawing, extract MainWindow helpers, split LagrangianDynamics init

### DIFF
--- a/src/movement_optimizer/gui/exercise_tab.py
+++ b/src/movement_optimizer/gui/exercise_tab.py
@@ -366,23 +366,28 @@ class ExerciseTab(QWidget):
         fk: dict[str, Any],
     ) -> None:
         """Render bench press: supine body on bench with arm chain."""
-        from matplotlib.patches import Circle as MplCircle
-
         ax.set_xlim(-0.6, 0.8)
         ax.set_ylim(-0.15, 1.4)
         ax.set_aspect("equal", adjustable="datalim")
 
         bench_h = 0.45
+        shoulder_x = -0.18
 
-        # Draw bench
-        ax.fill_between([-0.8, 0.5], bench_h - 0.05, bench_h, color="#8B4513", alpha=0.6)
+        self._draw_bench_body(ax, bench_h, shoulder_x)
+        arm_joints, fk_points = self._draw_bench_arm_segments(ax, bench_h, shoulder_x, fk)
+        self._draw_bench_barbell(ax, arm_joints, fk_points, bench_h, shoulder_x, fi, result)
+        self._draw_bench_annotations(ax, q, t_now)
 
-        # Draw body lying on bench (decorative -- not part of dynamics)
-        # Shoulder is near the head end (top of torso), not mid-body
+    def _draw_bench_body(self, ax: Any, bench_h: float, shoulder_x: float) -> None:
+        """Draw the decorative supine body on the bench (not part of dynamics)."""
+        from matplotlib.patches import Circle as MplCircle
+
         head_x, head_y = -0.40, bench_h + 0.05
         neck_x = -0.30
-        shoulder_x = -0.18
         hip_x = 0.30
+
+        # Bench surface
+        ax.fill_between([-0.8, 0.5], bench_h - 0.05, bench_h, color="#8B4513", alpha=0.6)
 
         # Neck
         ax.plot(
@@ -443,11 +448,12 @@ class ExerciseTab(QWidget):
         # Ground line
         ax.plot([-0.6, 0.8], [0, 0], color=Palette.FG_DIM, lw=2, alpha=0.3)
 
-        # Arm chain from FK (the actual dynamics)
-        # FK "ankle" = shoulder joint position, remap to bench shoulder position
+    def _draw_bench_arm_segments(
+        self, ax: Any, bench_h: float, shoulder_x: float, fk: dict[str, Any]
+    ) -> tuple[list[Any], list[Any]]:
+        """Draw the arm kinematic chain and return joint positions and FK points."""
         arm_base = np.array([shoulder_x, bench_h + 0.02])
         fk_points = [fk["ankle"], fk["knee"], fk["hip"], fk["shoulder"]]
-        # Offset FK relative to arm_base (FK has ankle at origin)
         arm_joints = [arm_base + (pt - fk_points[0]) for pt in fk_points]
 
         # Draw arm segments: upper arm, forearm, hand/wrist
@@ -475,15 +481,29 @@ class ExerciseTab(QWidget):
                 markeredgewidth=1,
             )
 
-        # Bar at hand position (end of chain)
+        return arm_joints, fk_points
+
+    def _draw_bench_barbell(
+        self,
+        ax: Any,
+        arm_joints: list[Any],
+        fk_points: list[Any],
+        bench_h: float,
+        shoulder_x: float,
+        fi: int,
+        result: OptimizationResult,
+    ) -> None:
+        """Draw the barbell at the hand position and the bar trace."""
         bar_pos = arm_joints[-1]
         BarbellRenderer.draw(ax, (bar_pos[0], bar_pos[1]))
 
-        # Bar trace — offset the FK-based trace to bench coordinates
+        arm_base = np.array([shoulder_x, bench_h + 0.02])
         bar_trace_offset = arm_base - fk_points[0]
         bench_bar_traj = result.bar + bar_trace_offset
         BodyRenderer.draw_bar_trace(ax, bench_bar_traj, fi)
 
+    def _draw_bench_annotations(self, ax: Any, q: Any, t_now: float) -> None:
+        """Draw the title annotation with current joint angles."""
         ax.set_title(
             f"{self.name}  t={t_now:.2f}s  |  "
             f"Shoulder {np.degrees(q[0]):.0f}\u00b0  "

--- a/src/movement_optimizer/gui/main_window.py
+++ b/src/movement_optimizer/gui/main_window.py
@@ -400,90 +400,126 @@ class MainWindow(QMainWindow):
             daemon=True,
         ).start()
 
+    def _build_exercise_config(
+        self, idx: int
+    ) -> tuple[Any, Any, Any, Any, Any, str, float, float, float, dict[str, float]]:
+        """Build the dynamics, poses, and parameters for an exercise.
+
+        Returns:
+            (dyn, qs, qe, qb, q_via, etype, bar, dur, smoothness, seg_mults)
+        """
+        body = self.sidebar.get_body_model()
+        bar = self.sidebar.bar_slider.value()
+        dur = self.sidebar.dur_slider.value()
+        smoothness = self.sidebar.smooth_slider.value()
+        _, etype = self.EXERCISE_CONFIGS[idx]
+
+        factory = EXERCISE_FACTORIES[etype]
+        config = factory(body, bar)
+        if len(config) == 5:
+            dyn, qs, qe, qb, q_via = config  # type: ignore[misc]
+        else:
+            dyn, qs, qe, qb = config  # type: ignore[misc]
+            q_via = None
+
+        # Enforce minimum duration for multi-phase exercises
+        _min_durations = {
+            "full_squat": 3.0,
+            "bench_press": 3.0,
+            "clean": 2.5,
+            "jerk": 2.0,
+            "snatch": 3.0,
+        }
+        if etype in _min_durations:
+            dur = max(dur, _min_durations[etype])
+
+        self.dynamics_list[idx] = dyn
+        self.bodies_list[idx] = body
+
+        seg_mults = {
+            "lower_leg": self.sidebar.ll_slider.value(),
+            "upper_leg": self.sidebar.ul_slider.value(),
+            "torso": self.sidebar.to_slider.value(),
+        }
+        return dyn, qs, qe, qb, q_via, etype, bar, dur, smoothness, seg_mults
+
+    def _run_optimizer(
+        self,
+        idx: int,
+        body: BodyModel,
+        dyn: Any,
+        qs: Any,
+        qe: Any,
+        qb: Any,
+        q_via: Any,
+        etype: str,
+        bar: float,
+        dur: float,
+        smoothness: float,
+        seg_mults: dict[str, float],
+    ) -> OptimizationResult:
+        """Run the trajectory optimizer (or return a cached result).
+
+        Raises CancelledError if the user cancels mid-run.
+        """
+        cached = self._cache.get(
+            etype, body.body_mass, body.height, seg_mults, bar, dur, smoothness
+        )
+        if cached is not None:
+            logger.info("Cache hit for %s", etype)
+            return cached
+
+        logger.info(
+            "Starting %s optimisation: mass=%.0f, height=%.2f, bar=%.0f",
+            etype,
+            body.body_mass,
+            body.height,
+            bar,
+        )
+
+        opt = TrajectoryOptimizer(
+            body,
+            dyn,  # type: ignore[arg-type]
+            etype,
+            bar,
+            qs,  # type: ignore[arg-type]
+            qe,  # type: ignore[arg-type]
+            qb,  # type: ignore[arg-type]
+            q_via=q_via,  # type: ignore[arg-type]
+            duration=dur,
+            n_waypoints=12,
+            smoothness=smoothness,
+            progress_cb=self._make_progress_cb(),
+            cancel_event=self._cancel_event,
+        )
+        result = opt.optimize()
+
+        self._cache.put(
+            etype,
+            body.body_mass,
+            body.height,
+            seg_mults,
+            bar,
+            dur,
+            smoothness,
+            result,
+        )
+        return result
+
     def _opt_worker(self, idx: int, then_chain: list[int] | None) -> None:
         try:
             body = self.sidebar.get_body_model()
-            bar = self.sidebar.bar_slider.value()
-            dur = self.sidebar.dur_slider.value()
-            smoothness = self.sidebar.smooth_slider.value()
-            _, etype = self.EXERCISE_CONFIGS[idx]
-
-            factory = EXERCISE_FACTORIES[etype]
-            config = factory(body, bar)
-            if len(config) == 5:
-                dyn, qs, qe, qb, q_via = config  # type: ignore[misc]
-            else:
-                dyn, qs, qe, qb = config  # type: ignore[misc]
-                q_via = None
-
-            # Enforce minimum duration for multi-phase exercises
-            _min_durations = {
-                "full_squat": 3.0,
-                "bench_press": 3.0,
-                "clean": 2.5,
-                "jerk": 2.0,
-                "snatch": 3.0,
-            }
-            if etype in _min_durations:
-                dur = max(dur, _min_durations[etype])
-
-            self.dynamics_list[idx] = dyn
-            self.bodies_list[idx] = body
-
-            seg_mults = {
-                "lower_leg": self.sidebar.ll_slider.value(),
-                "upper_leg": self.sidebar.ul_slider.value(),
-                "torso": self.sidebar.to_slider.value(),
-            }
-            cached = self._cache.get(
-                etype, body.body_mass, body.height, seg_mults, bar, dur, smoothness
-            )
-            if cached is not None:
-                logger.info("Cache hit for %s", etype)
-                result = cached
-                self.results[idx] = result
-                self.anim_frames[idx] = 0
-                self._sig_done.emit(idx, result, body, bar, then_chain)
-                return
-
-            logger.info(
-                "Starting %s optimisation: mass=%.0f, height=%.2f, bar=%.0f",
-                etype,
-                body.body_mass,
-                body.height,
-                bar,
+            dyn, qs, qe, qb, q_via, etype, bar, dur, smoothness, seg_mults = (
+                self._build_exercise_config(idx)
             )
 
-            opt = TrajectoryOptimizer(
-                body,
-                dyn,  # type: ignore[arg-type]
-                etype,
-                bar,
-                qs,  # type: ignore[arg-type]
-                qe,  # type: ignore[arg-type]
-                qb,  # type: ignore[arg-type]
-                q_via=q_via,  # type: ignore[arg-type]
-                duration=dur,
-                n_waypoints=12,
-                smoothness=smoothness,
-                progress_cb=self._make_progress_cb(),
-                cancel_event=self._cancel_event,
+            result = self._run_optimizer(
+                idx, body, dyn, qs, qe, qb, q_via, etype, bar, dur, smoothness, seg_mults
             )
-            result = opt.optimize()
+
             with self._opt_lock:
                 self.results[idx] = result
                 self.anim_frames[idx] = 0
-
-            self._cache.put(
-                etype,
-                body.body_mass,
-                body.height,
-                seg_mults,
-                bar,
-                dur,
-                smoothness,
-                result,
-            )
 
             self._sig_done.emit(idx, result, body, bar, then_chain)
         except CancelledError:
@@ -651,6 +687,23 @@ class MainWindow(QMainWindow):
             delay = 700
         self.anim_timer.start(delay)
 
+    def _draw_current_frame(self, idx: int) -> None:
+        """Render the current animation frame for the given exercise tab."""
+        r = self.results[idx]
+        if r is None:
+            return
+        fi = self.anim_frames[idx]
+        _, etype = self.EXERCISE_CONFIGS[idx]
+        self.exercise_tabs[idx].draw_anim_frame(
+            fi,
+            r,
+            self.dynamics_list[idx],
+            self.bodies_list[idx],  # type: ignore[arg-type]
+            etype,
+        )
+        n = len(r.t)
+        self.controls.frame_label.setText(f"Frame {fi + 1}/{n}")
+
     def _step_fwd(self) -> None:
         idx = self.tabs.currentIndex()
         r = self.results[idx]
@@ -659,15 +712,7 @@ class MainWindow(QMainWindow):
         self._stop_anim()
         n = len(r.t)
         self.anim_frames[idx] = (self.anim_frames[idx] + 1) % n
-        _, etype = self.EXERCISE_CONFIGS[idx]
-        self.exercise_tabs[idx].draw_anim_frame(
-            self.anim_frames[idx],
-            r,
-            self.dynamics_list[idx],
-            self.bodies_list[idx],  # type: ignore[arg-type]
-            etype,
-        )
-        self.controls.frame_label.setText(f"Frame {self.anim_frames[idx] + 1}/{n}")
+        self._draw_current_frame(idx)
 
     def _step_back(self) -> None:
         idx = self.tabs.currentIndex()
@@ -677,14 +722,7 @@ class MainWindow(QMainWindow):
         self._stop_anim()
         n = len(r.t)
         self.anim_frames[idx] = (self.anim_frames[idx] - 1) % n
-        _, etype = self.EXERCISE_CONFIGS[idx]
-        self.exercise_tabs[idx].draw_anim_frame(
-            self.anim_frames[idx],
-            r,
-            self.dynamics_list[idx],
-            self.bodies_list[idx],  # type: ignore[arg-type]
-            etype,
-        )
+        self._draw_current_frame(idx)
 
     def _rewind(self) -> None:
         idx = self.tabs.currentIndex()
@@ -693,14 +731,7 @@ class MainWindow(QMainWindow):
             return
         self._stop_anim()
         self.anim_frames[idx] = 0
-        _, etype = self.EXERCISE_CONFIGS[idx]
-        self.exercise_tabs[idx].draw_anim_frame(
-            0,
-            r,
-            self.dynamics_list[idx],
-            self.bodies_list[idx],  # type: ignore[arg-type]
-            etype,
-        )
+        self._draw_current_frame(idx)
 
     def _on_speed(self, speed: float) -> None:
         self.controls.speed_label.setText(f"{speed:.1f}x")

--- a/src/movement_optimizer/models.py
+++ b/src/movement_optimizer/models.py
@@ -353,7 +353,19 @@ class LagrangianDynamics(PhysicsBackend):
             L = body.L
             d = body.d
 
-        # Pre-compute coupling coefficients (constant for given model)
+        self._init_coupling_coefficients(m_segments, I_segments, load_mass, L, d)
+        self._init_gravity_coefficients(m_segments, load_mass, L, d)
+
+    def _init_coupling_coefficients(
+        self,
+        m_segments: NDArray,
+        I_segments: NDArray,
+        load_mass: float,
+        L: NDArray,
+        d: NDArray,
+    ) -> None:
+        """Pre-compute coupling and diagonal mass-matrix constants."""
+        # Off-diagonal coupling coefficients
         self._a01 = (m_segments[1] * d[1] + (m_segments[2] + load_mass) * L[1]) * L[0]
         self._a02 = (m_segments[2] * d[2] + load_mass * L[2]) * L[0]
         self._a12 = (m_segments[2] * d[2] + load_mass * L[2]) * L[1]
@@ -369,12 +381,19 @@ class LagrangianDynamics(PhysicsBackend):
         )
         self._M22 = m_segments[2] * d[2] ** 2 + load_mass * L[2] ** 2 + I_segments[2]
 
-        # Gravity coefficients
-        self._g0 = body.g * (
+    def _init_gravity_coefficients(
+        self,
+        m_segments: NDArray,
+        load_mass: float,
+        L: NDArray,
+        d: NDArray,
+    ) -> None:
+        """Pre-compute gravity torque coefficients."""
+        self._g0 = self.body.g * (
             m_segments[0] * d[0] + (m_segments[1] + m_segments[2] + load_mass) * L[0]
         )
-        self._g1 = body.g * (m_segments[1] * d[1] + (m_segments[2] + load_mass) * L[1])
-        self._g2 = body.g * (m_segments[2] * d[2] + load_mass * L[2])
+        self._g1 = self.body.g * (m_segments[1] * d[1] + (m_segments[2] + load_mass) * L[1])
+        self._g2 = self.body.g * (m_segments[2] * d[2] + load_mass * L[2])
 
     @property
     def n_dof(self) -> int:


### PR DESCRIPTION
## Summary
- **#172**: Split `_draw_bench_press_frame` (137 lines) into 4 composable helpers: `_draw_bench_body()`, `_draw_bench_arm_segments()`, `_draw_bench_barbell()`, `_draw_bench_annotations()`
- **#173**: Extract 3 helpers from `MainWindow`: `_build_exercise_config()`, `_run_optimizer()`, `_draw_current_frame()` — reduces repeated frame-drawing logic across `_step_fwd`, `_step_back`, `_rewind`
- **#174**: Extract `_init_coupling_coefficients()` and `_init_gravity_coefficients()` from `LagrangianDynamics.__init__`

All 265 tests pass, ruff clean.

Closes #172, #173, #174

## Test plan
- [x] All 265 tests pass locally
- [x] `ruff check` and `ruff format` clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)