### PR TITLE
feat: publish movement optimizer provider pack

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -11,8 +11,8 @@
 | License | MIT |
 | Package Name | `movement-optimizer` |
 | Current Version | `1.0.0` |
-| Spec Version | `1.0.0` |
-| Last Spec Update | 2026-04-06 |
+| Spec Version | `1.0.1` |
+| Last Spec Update | 2026-04-09 |
 
 ## 2. Purpose
 
@@ -130,4 +130,5 @@ mypy --ignore-missing-imports src/movement_optimizer/
 
 | Date | Version | Changes |
 | --- | --- | --- |
+| 2026-04-09 | 1.0.1 | Added a shared provider-pack manifest, validator, regression tests, and launcher icon asset so Movement-Optimizer can publish a launcher-compatible utility pack without embedding UpstreamDrift-specific path logic. |
 | 2026-04-06 | 1.0.0 | Initial repository specification aligned to the current package layout, entrypoints, and test contract. |

--- a/assets/movement_optimizer_icon.svg
+++ b/assets/movement_optimizer_icon.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-label="Movement Optimizer">
+  <rect width="128" height="128" rx="20" fill="#f4efe6"/>
+  <rect x="18" y="58" width="92" height="12" rx="6" fill="#1e3a5f"/>
+  <rect x="12" y="44" width="8" height="40" rx="4" fill="#c05a2b"/>
+  <rect x="108" y="44" width="8" height="40" rx="4" fill="#c05a2b"/>
+  <circle cx="40" cy="64" r="10" fill="#7aa6c2"/>
+  <circle cx="88" cy="64" r="10" fill="#7aa6c2"/>
+  <path d="M28 95c10-14 24-21 36-21s26 7 36 21" fill="none" stroke="#2f6b3b" stroke-linecap="round" stroke-width="8"/>
+</svg>

--- a/model_pack.yaml
+++ b/model_pack.yaml
@@ -1,0 +1,28 @@
+manifest_version: "1.0.0"
+pack_id: "movement-optimizer-utilities"
+pack_name: "Movement Optimizer Utilities"
+provider: "movement_optimizer"
+models:
+  - id: "movement_optimizer"
+    name: "Movement Optimizer"
+    description: "Trajectory optimization utility for barbell and movement exercises with GUI and CLI entry points."
+    type: "special_app"
+    path: "src/movement_optimizer/__main__.py"
+    source_root: "."
+    working_dir: "."
+    python_paths:
+      - "src"
+    capabilities:
+      - "optimization"
+      - "biomechanics"
+      - "trajectory"
+      - "cli"
+    tags:
+      - "barbell"
+      - "exercise"
+      - "lagrangian"
+    launcher:
+      category: "tool"
+      logo: "assets/movement_optimizer_icon.svg"
+      status: "provider_ready"
+      web_route: "/tools/movement-optimizer"

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Utility scripts that are importable from the repo test suite."""

--- a/scripts/movement_provider_manifest.py
+++ b/scripts/movement_provider_manifest.py
@@ -1,0 +1,128 @@
+"""Validation helpers for the Movement Optimizer provider manifest."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MOVEMENT_PROVIDER_MANIFEST = REPO_ROOT / "model_pack.yaml"
+
+_REQUIRED_TOP_LEVEL_FIELDS = (
+    "manifest_version",
+    "pack_id",
+    "pack_name",
+    "provider",
+    "models",
+)
+_REQUIRED_MODEL_FIELDS = (
+    "id",
+    "name",
+    "description",
+    "type",
+    "path",
+    "source_root",
+    "working_dir",
+    "python_paths",
+    "capabilities",
+    "launcher",
+)
+_REQUIRED_LAUNCHER_FIELDS = ("category", "logo", "status")
+
+
+def load_movement_provider_manifest(path: Path = MOVEMENT_PROVIDER_MANIFEST) -> dict[str, Any]:
+    """Load the movement-optimizer provider manifest from disk."""
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("movement provider manifest must deserialize to a mapping")
+    return data
+
+
+def _require_fields(
+    payload: dict[str, Any],
+    required_fields: tuple[str, ...],
+    *,
+    label: str,
+) -> None:
+    missing = [field for field in required_fields if field not in payload]
+    if missing:
+        raise ValueError(f"{label} missing required fields: {missing}")
+
+
+def _resolve_repo_relative_path(repo_root: Path, relative_path: str, *, label: str) -> Path:
+    path = (repo_root / relative_path).resolve(strict=False)
+    if not path.exists():
+        raise ValueError(f"{label} does not exist: {path}")
+    return path
+
+
+def validate_movement_provider_manifest(
+    repo_root: Path = REPO_ROOT,
+    path: Path = MOVEMENT_PROVIDER_MANIFEST,
+) -> dict[str, Any]:
+    """Validate the optimizer provider manifest against the local repo layout."""
+    manifest = load_movement_provider_manifest(path)
+    _require_fields(manifest, _REQUIRED_TOP_LEVEL_FIELDS, label="manifest")
+
+    models = manifest["models"]
+    if not isinstance(models, list) or not models:
+        raise ValueError("manifest must contain at least one model entry")
+
+    model_ids: set[str] = set()
+    for model in models:
+        if not isinstance(model, dict):
+            raise ValueError("model entries must be mappings")
+        _require_fields(model, _REQUIRED_MODEL_FIELDS, label=f"model[{model.get('id', '?')}]")
+
+        model_id = model["id"]
+        if not isinstance(model_id, str) or not model_id.strip():
+            raise ValueError("model id must be a non-empty string")
+        if model_id in model_ids:
+            raise ValueError(f"duplicate model id: {model_id}")
+        model_ids.add(model_id)
+
+        source_root = _resolve_repo_relative_path(
+            repo_root,
+            str(model["source_root"]),
+            label=f"{model_id}.source_root",
+        )
+        artifact_path = (source_root / str(model["path"])).resolve(strict=False)
+        if not artifact_path.exists():
+            raise ValueError(f"{model_id}.path does not exist: {artifact_path}")
+
+        _resolve_repo_relative_path(
+            repo_root,
+            str(model["working_dir"]),
+            label=f"{model_id}.working_dir",
+        )
+
+        python_paths = model["python_paths"]
+        if not isinstance(python_paths, list) or not python_paths:
+            raise ValueError(f"{model_id}.python_paths must be a non-empty list")
+        for index, python_path in enumerate(python_paths):
+            _resolve_repo_relative_path(
+                repo_root,
+                str(python_path),
+                label=f"{model_id}.python_paths[{index}]",
+            )
+
+        capabilities = model["capabilities"]
+        if not isinstance(capabilities, list) or not capabilities:
+            raise ValueError(f"{model_id}.capabilities must be a non-empty list")
+
+        launcher = model["launcher"]
+        if not isinstance(launcher, dict):
+            raise ValueError(f"{model_id}.launcher must be a mapping")
+        _require_fields(launcher, _REQUIRED_LAUNCHER_FIELDS, label=f"{model_id}.launcher")
+        if launcher["category"] != "tool":
+            raise ValueError(f"{model_id}.launcher.category must be 'tool'")
+
+        _resolve_repo_relative_path(
+            repo_root,
+            str(launcher["logo"]),
+            label=f"{model_id}.launcher.logo",
+        )
+
+    return manifest

--- a/tests/test_movement_provider_manifest.py
+++ b/tests/test_movement_provider_manifest.py
@@ -1,0 +1,59 @@
+"""Regression tests for the shared Movement Optimizer provider manifest."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import tomllib
+
+from scripts.movement_provider_manifest import (
+    MOVEMENT_PROVIDER_MANIFEST,
+    REPO_ROOT,
+    validate_movement_provider_manifest,
+)
+
+
+def test_movement_provider_manifest_validates_against_repo_layout() -> None:
+    """The published optimizer pack should resolve cleanly from the repo root."""
+    manifest = validate_movement_provider_manifest()
+
+    assert manifest["pack_id"] == "movement-optimizer-utilities"
+    assert manifest["provider"] == "movement_optimizer"
+    assert len(manifest["models"]) == 1
+
+
+def test_movement_provider_manifest_declares_shared_launcher_metadata() -> None:
+    """The optimizer pack should expose launcher metadata for shared consumers."""
+    manifest = validate_movement_provider_manifest()
+    entry = manifest["models"][0]
+
+    assert entry["capabilities"] == [
+        "optimization",
+        "biomechanics",
+        "trajectory",
+        "cli",
+    ]
+    assert entry["launcher"] == {
+        "category": "tool",
+        "logo": "assets/movement_optimizer_icon.svg",
+        "status": "provider_ready",
+        "web_route": "/tools/movement-optimizer",
+    }
+
+
+def test_movement_provider_manifest_points_at_console_entry_module() -> None:
+    """The provider path should track the installed console entry module."""
+    manifest = validate_movement_provider_manifest()
+    entry = manifest["models"][0]
+    pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+
+    assert pyproject["project"]["scripts"]["movement-optimizer"] == (
+        "movement_optimizer.__main__:main"
+    )
+    assert entry["path"] == "src/movement_optimizer/__main__.py"
+
+
+def test_movement_provider_manifest_stays_in_expected_location() -> None:
+    """The shared optimizer manifest should remain a top-level provider artifact."""
+    assert MOVEMENT_PROVIDER_MANIFEST == REPO_ROOT / "model_pack.yaml"
+    assert Path(MOVEMENT_PROVIDER_MANIFEST).is_file()


### PR DESCRIPTION
## Summary
- add a shared provider-pack manifest so Movement-Optimizer can publish launcher-compatible utility metadata without UpstreamDrift-specific path assumptions
- add a small validator and regression tests that keep the manifest aligned with the real console entry point, source paths, and launcher asset metadata
- add a lightweight SVG launcher icon and update SPEC.md for the new shared-launch contract surface

## Testing
- python -m pytest tests/test_movement_provider_manifest.py -q
- python -m ruff check scripts/movement_provider_manifest.py tests/test_movement_provider_manifest.py
- python -m ruff format --check scripts/movement_provider_manifest.py tests/test_movement_provider_manifest.py

Closes #205