### PR TITLE
feat(#205): publish optimization utilities as shared launcher-compatible provider pack

### DIFF
--- a/model_pack.yaml
+++ b/model_pack.yaml
@@ -1,0 +1,39 @@
+manifest_version: "1.0.0"
+pack_id: "movement-optimizer"
+pack_name: "Movement Optimizer"
+provider: "movement_optimizer"
+description: >
+  Biomechanics trajectory optimizer for barbell exercises using Lagrangian
+  inverse dynamics in the sagittal plane. Models the body as a 3-link planar
+  chain and exposes a PyQt6 GUI with multi-start parallel SLSQP optimization.
+source_repo: "https://github.com/D-sorganization/Movement-Optimizer"
+models:
+  - id: "movement_optimizer"
+    name: "Movement Optimizer"
+    description: >
+      Optimal barbell exercise trajectory optimizer. Computes joint kinematics
+      and torques for squat, deadlift, bench press, clean, snatch, jerk, gait,
+      and sit-to-stand via Lagrangian inverse dynamics with a PyQt6 GUI.
+    type: "tool"
+    path: "src/movement_optimizer/__main__.py"
+    source_root: "."
+    working_dir: "."
+    python_paths:
+      - "src"
+    capabilities:
+      - "trajectory-optimization"
+      - "inverse-dynamics"
+      - "biomechanics"
+      - "visualization"
+    tags:
+      - "barbell"
+      - "squat"
+      - "deadlift"
+      - "biomechanics"
+      - "lagrangian"
+      - "pyqt6"
+    launcher:
+      category: "tool"
+      status: "provider_ready"
+      web_route: "/tools/movement-optimizer"
+    order: 10

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Movement-Optimizer scripts package."""

--- a/scripts/provider_manifest.py
+++ b/scripts/provider_manifest.py
@@ -1,0 +1,203 @@
+"""Validation helpers for the Movement-Optimizer shared launcher provider manifest.
+
+This module exposes a contract-tested validation function used by:
+ - The test suite (TDD regression coverage)
+ - CI (provider compatibility gate)
+ - UpstreamDrift's shared harness when onboarding this provider pack
+
+Design by Contract:
+  Preconditions:
+    - manifest_path must exist and contain valid YAML
+  Postconditions:
+    - Returned manifest passes all required-field checks
+    - All referenced paths exist relative to repo_root
+  Invariants:
+    - Validation is side-effect-free (read-only)
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PROVIDER_MANIFEST_PATH = REPO_ROOT / "model_pack.yaml"
+
+_OPTIONAL_DEPENDENCIES: dict[str, str] = {
+    "maturin": "Rust/PyO3 extension build tooling (rust_core acceleration)",
+    "jax": "JAX GPU-accelerated dynamics backend",
+}
+
+_REQUIRED_TOP_LEVEL_FIELDS = (
+    "manifest_version",
+    "pack_id",
+    "pack_name",
+    "provider",
+    "models",
+)
+_REQUIRED_MODEL_FIELDS = (
+    "id",
+    "name",
+    "description",
+    "type",
+    "path",
+    "source_root",
+    "working_dir",
+    "python_paths",
+    "capabilities",
+    "launcher",
+)
+_REQUIRED_LAUNCHER_FIELDS = ("category", "status")
+
+
+def load_provider_manifest(
+    manifest_path: Path = PROVIDER_MANIFEST_PATH,
+) -> dict[str, Any]:
+    """Load the provider manifest YAML from disk.
+
+    Args:
+        manifest_path: Path to the model_pack.yaml file.
+
+    Returns:
+        Parsed manifest dictionary.
+
+    Raises:
+        FileNotFoundError: If the manifest file does not exist.
+        ValueError: If the file does not parse to a mapping.
+    """
+    if not manifest_path.exists():
+        raise FileNotFoundError(f"provider manifest not found: {manifest_path}")
+    data = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("provider manifest must deserialize to a mapping")
+    return data
+
+
+def _require_fields(
+    payload: dict[str, Any],
+    required_fields: tuple[str, ...],
+    *,
+    label: str,
+) -> None:
+    missing = [field for field in required_fields if field not in payload]
+    if missing:
+        raise ValueError(f"{label} missing required fields: {missing}")
+
+
+def validate_provider_manifest(
+    repo_root: Path = REPO_ROOT,
+    manifest_path: Path = PROVIDER_MANIFEST_PATH,
+) -> dict[str, Any]:
+    """Validate the provider manifest against the local repository layout.
+
+    Checks that:
+    - All required top-level and per-model fields are present.
+    - source_root and working_dir directories exist.
+    - The primary artifact path (path relative to source_root) exists.
+    - All python_paths entries exist.
+    - At least one model entry is declared.
+    - Each launcher block has the required keys.
+
+    Args:
+        repo_root: Repository root for resolving relative paths.
+        manifest_path: Path to the model_pack.yaml to validate.
+
+    Returns:
+        The validated manifest dictionary.
+
+    Raises:
+        ValueError: If any contract violation is found.
+        FileNotFoundError: If manifest_path does not exist.
+    """
+    manifest = load_provider_manifest(manifest_path)
+    _require_fields(manifest, _REQUIRED_TOP_LEVEL_FIELDS, label="manifest")
+
+    models = manifest["models"]
+    if not isinstance(models, list) or not models:
+        raise ValueError("manifest must contain at least one model entry")
+
+    seen_ids: set[str] = set()
+    for model in models:
+        if not isinstance(model, dict):
+            raise ValueError("model entries must be mappings")
+        _require_fields(model, _REQUIRED_MODEL_FIELDS, label=f"model[{model.get('id', '?')}]")
+
+        model_id = model["id"]
+        if not isinstance(model_id, str) or not model_id.strip():
+            raise ValueError("model id must be a non-empty string")
+        if model_id in seen_ids:
+            raise ValueError(f"duplicate model id: {model_id!r}")
+        seen_ids.add(model_id)
+
+        source_root = (repo_root / str(model["source_root"])).resolve(strict=False)
+        if not source_root.exists():
+            raise ValueError(f"{model_id}.source_root does not exist: {source_root}")
+
+        artifact_path = (source_root / str(model["path"])).resolve(strict=False)
+        if not artifact_path.exists():
+            raise ValueError(f"{model_id}.path does not exist: {artifact_path}")
+
+        working_dir = (repo_root / str(model["working_dir"])).resolve(strict=False)
+        if not working_dir.is_dir():
+            raise ValueError(f"{model_id}.working_dir does not exist: {working_dir}")
+
+        python_paths = model["python_paths"]
+        if not isinstance(python_paths, list) or not python_paths:
+            raise ValueError(f"{model_id}.python_paths must be a non-empty list")
+        for index, python_path in enumerate(python_paths):
+            path = (repo_root / str(python_path)).resolve(strict=False)
+            if not path.is_dir():
+                raise ValueError(f"{model_id}.python_paths[{index}] does not exist: {path}")
+
+        capabilities = model["capabilities"]
+        if not isinstance(capabilities, list) or not capabilities:
+            raise ValueError(f"{model_id}.capabilities must be a non-empty list")
+
+        launcher = model.get("launcher", {})
+        if not isinstance(launcher, dict):
+            raise ValueError(f"{model_id}.launcher must be a mapping")
+        _require_fields(launcher, _REQUIRED_LAUNCHER_FIELDS, label=f"{model_id}.launcher")
+        if launcher["category"] != "tool":
+            raise ValueError(f"{model_id}.launcher.category must be 'tool' for utility providers")
+
+    return manifest
+
+
+def check_optional_dependencies(
+    extra_optional_deps: dict[str, str] | None = None,
+) -> list[str]:
+    """Check which optional dependencies are unavailable and surface diagnostics.
+
+    Returns a list of human-readable diagnostic strings, one per missing
+    optional dependency.  An empty list means all optional dependencies are
+    installed.
+
+    Args:
+        extra_optional_deps: Additional {package_name: description} pairs to
+            check beyond the built-in optional dependency table.
+
+    Returns:
+        List of diagnostic strings for unavailable optional dependencies.
+    """
+    all_optional = dict(_OPTIONAL_DEPENDENCIES)
+    if extra_optional_deps:
+        all_optional.update(extra_optional_deps)
+
+    issues: list[str] = []
+    for package_name, description in all_optional.items():
+        try:
+            spec = importlib.util.find_spec(package_name)
+            if spec is None:
+                issues.append(
+                    f"Optional dependency '{package_name}' not available "
+                    f"({description}). Some features may be degraded."
+                )
+        except (ModuleNotFoundError, ValueError):
+            issues.append(
+                f"Optional dependency '{package_name}' not available "
+                f"({description}). Some features may be degraded."
+            )
+    return issues

--- a/tests/test_provider_manifest.py
+++ b/tests/test_provider_manifest.py
@@ -1,0 +1,199 @@
+"""TDD tests for the Movement-Optimizer shared launcher provider manifest.
+
+Tests are written before the implementation (Red) and drive the design of:
+ - model_pack.yaml — the provider manifest consumed by UpstreamDrift
+ - scripts/provider_manifest.py — validation helpers
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MANIFEST_PATH = REPO_ROOT / "model_pack.yaml"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_manifest() -> dict:
+    data = yaml.safe_load(MANIFEST_PATH.read_text(encoding="utf-8"))
+    assert isinstance(data, dict), "manifest must deserialize to a mapping"
+    return data
+
+
+# ---------------------------------------------------------------------------
+# 1. Manifest file existence and top-level contract
+# ---------------------------------------------------------------------------
+
+
+class TestManifestExists:
+    def test_model_pack_yaml_exists_at_repo_root(self) -> None:
+        assert MANIFEST_PATH.is_file(), f"model_pack.yaml not found at {MANIFEST_PATH}"
+
+
+class TestManifestTopLevel:
+    def test_has_required_top_level_fields(self) -> None:
+        manifest = _load_manifest()
+        required = {"manifest_version", "pack_id", "pack_name", "provider", "models"}
+        missing = required - set(manifest.keys())
+        assert not missing, f"manifest missing required fields: {missing}"
+
+    def test_provider_is_movement_optimizer(self) -> None:
+        manifest = _load_manifest()
+        assert manifest["provider"] == "movement_optimizer"
+
+    def test_pack_id_is_stable(self) -> None:
+        manifest = _load_manifest()
+        assert manifest["pack_id"] == "movement-optimizer"
+
+    def test_manifest_version_is_semver(self) -> None:
+        manifest = _load_manifest()
+        version = manifest["manifest_version"]
+        assert isinstance(version, str) and len(version.split(".")) == 3
+
+
+# ---------------------------------------------------------------------------
+# 2. Model entry contract
+# ---------------------------------------------------------------------------
+
+
+class TestManifestModels:
+    def test_has_at_least_one_model(self) -> None:
+        manifest = _load_manifest()
+        assert len(manifest["models"]) >= 1
+
+    def test_each_model_has_required_fields(self) -> None:
+        manifest = _load_manifest()
+        required = {"id", "name", "description", "type", "path"}
+        for model in manifest["models"]:
+            missing = required - set(model.keys())
+            assert not missing, f"model[{model.get('id')}] missing: {missing}"
+
+    def test_optimizer_entry_is_present(self) -> None:
+        manifest = _load_manifest()
+        ids = {m["id"] for m in manifest["models"]}
+        assert "movement_optimizer" in ids
+
+    def test_model_ids_are_unique(self) -> None:
+        manifest = _load_manifest()
+        ids = [m["id"] for m in manifest["models"]]
+        assert len(ids) == len(set(ids)), "duplicate model ids"
+
+    def test_main_entry_type_is_tool(self) -> None:
+        manifest = _load_manifest()
+        entry = next(m for m in manifest["models"] if m["id"] == "movement_optimizer")
+        assert entry["type"] == "tool"
+
+    def test_main_entry_path_points_at_valid_file(self) -> None:
+        manifest = _load_manifest()
+        entry = next(m for m in manifest["models"] if m["id"] == "movement_optimizer")
+        artifact = REPO_ROOT / entry["path"]
+        assert artifact.is_file(), f"entry path does not exist: {artifact}"
+
+    def test_working_dir_exists(self) -> None:
+        manifest = _load_manifest()
+        entry = next(m for m in manifest["models"] if m["id"] == "movement_optimizer")
+        working_dir = REPO_ROOT / entry["working_dir"]
+        assert working_dir.is_dir(), f"working_dir does not exist: {working_dir}"
+
+    def test_python_paths_are_non_empty_list(self) -> None:
+        manifest = _load_manifest()
+        entry = next(m for m in manifest["models"] if m["id"] == "movement_optimizer")
+        python_paths = entry.get("python_paths", [])
+        assert isinstance(python_paths, list)
+        assert len(python_paths) >= 1
+
+    def test_python_paths_exist(self) -> None:
+        manifest = _load_manifest()
+        entry = next(m for m in manifest["models"] if m["id"] == "movement_optimizer")
+        for python_path in entry.get("python_paths", []):
+            path = REPO_ROOT / python_path
+            assert path.is_dir(), f"python_path does not exist: {path}"
+
+
+# ---------------------------------------------------------------------------
+# 3. Capabilities and metadata
+# ---------------------------------------------------------------------------
+
+
+class TestManifestCapabilities:
+    def test_main_entry_declares_capabilities(self) -> None:
+        manifest = _load_manifest()
+        entry = next(m for m in manifest["models"] if m["id"] == "movement_optimizer")
+        caps = entry.get("capabilities", [])
+        assert isinstance(caps, list) and len(caps) >= 1
+
+    def test_main_entry_declares_launcher_metadata(self) -> None:
+        manifest = _load_manifest()
+        entry = next(m for m in manifest["models"] if m["id"] == "movement_optimizer")
+        launcher = entry.get("launcher", {})
+        required = {"category", "status"}
+        missing = required - set(launcher.keys())
+        assert not missing, f"launcher metadata missing: {missing}"
+
+    def test_launcher_category_is_tool(self) -> None:
+        manifest = _load_manifest()
+        entry = next(m for m in manifest["models"] if m["id"] == "movement_optimizer")
+        assert entry["launcher"]["category"] == "tool"
+
+
+# ---------------------------------------------------------------------------
+# 4. Compatibility validation helper
+# ---------------------------------------------------------------------------
+
+
+class TestValidationHelper:
+    def test_validate_function_returns_manifest_dict(self) -> None:
+        from scripts.provider_manifest import validate_provider_manifest
+
+        result = validate_provider_manifest()
+        assert isinstance(result, dict)
+        assert result["provider"] == "movement_optimizer"
+
+    def test_validate_raises_for_missing_required_field(self, tmp_path: Path) -> None:
+        from scripts.provider_manifest import validate_provider_manifest
+
+        bad_manifest = tmp_path / "model_pack.yaml"
+        bad_manifest.write_text(
+            "manifest_version: '1.0.0'\npack_id: 'test'\npack_name: 'Test'\n",
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="missing required"):
+            validate_provider_manifest(manifest_path=bad_manifest)
+
+    def test_validate_raises_for_empty_models(self, tmp_path: Path) -> None:
+        from scripts.provider_manifest import validate_provider_manifest
+
+        bad_manifest = tmp_path / "model_pack.yaml"
+        bad_manifest.write_text(
+            "manifest_version: '1.0.0'\npack_id: 'x'\npack_name: 'X'\nprovider: 'x'\nmodels: []\n",
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="at least one"):
+            validate_provider_manifest(manifest_path=bad_manifest)
+
+
+# ---------------------------------------------------------------------------
+# 5. Optional dependency diagnostics
+# ---------------------------------------------------------------------------
+
+
+class TestOptionalDependencyDiagnostics:
+    def test_optional_dep_check_returns_list(self) -> None:
+        from scripts.provider_manifest import check_optional_dependencies
+
+        issues = check_optional_dependencies()
+        assert isinstance(issues, list)
+
+    def test_unavailable_optional_dep_surfaces_diagnostic(self) -> None:
+        from scripts.provider_manifest import check_optional_dependencies
+
+        issues = check_optional_dependencies(
+            extra_optional_deps={"_nonexistent_package_xyz_": "rust acceleration"}
+        )
+        assert any("_nonexistent_package_xyz_" in issue for issue in issues)


### PR DESCRIPTION
## Summary
- Adds `model_pack.yaml` at the repo root exposing Movement-Optimizer as a shared launcher provider pack consumable by UpstreamDrift
- Adds `scripts/provider_manifest.py` with contract-tested validation helpers (required-field checks, path resolution, optional dependency diagnostics)
- Adds 22 TDD tests in `tests/test_provider_manifest.py` covering manifest contract, per-model field validation, launcher metadata, and degraded-unavailable state surfacing

## Design decisions
- `source_root: "."` (repo root) keeps the manifest self-contained; `working_dir: "."` mirrors the installed entry point
- `python_paths: ["src"]` is the single source of truth for the importable package tree
- Optional dependency checks (`jax`, `maturin`) surface friendly diagnostics rather than hard failures, satisfying the acceptance criterion for degraded unavailable states
- No launcher path assumptions are embedded in `src/`; all provider metadata lives exclusively in `model_pack.yaml`

## Test plan
- [ ] `PYTHONPATH=src python3 -m pytest tests/test_provider_manifest.py -v` → 22 passed
- [ ] `ruff check scripts/ tests/test_provider_manifest.py` → no violations
- [ ] CI passes (ruff, mypy, pytest)

Closes #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)