### PR TITLE
fix: replace CLI print with stdout writer

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -11,8 +11,8 @@
 | License | MIT |
 | Package Name | `movement-optimizer` |
 | Current Version | `1.0.0` |
-| Spec Version | `1.0.1` |
-| Last Spec Update | 2026-04-09 |
+| Spec Version | `1.0.2` |
+| Last Spec Update | 2026-04-10 |
 
 ## 2. Purpose
 
@@ -130,5 +130,6 @@ mypy --ignore-missing-imports src/movement_optimizer/
 
 | Date | Version | Changes |
 | --- | --- | --- |
+| 2026-04-10 | 1.0.2 | Replaced the last `print()` call in `src/` with direct stdout JSON emission in the CLI summary path and updated the CLI regression test to preserve the headless output contract without violating the no-print rule. |
 | 2026-04-09 | 1.0.1 | Added a shared provider-pack manifest, validator, regression tests, and launcher icon asset so Movement-Optimizer can publish a launcher-compatible utility pack without embedding UpstreamDrift-specific path logic. |
 | 2026-04-06 | 1.0.0 | Initial repository specification aligned to the current package layout, entrypoints, and test contract. |

--- a/src/movement_optimizer/cli.py
+++ b/src/movement_optimizer/cli.py
@@ -145,10 +145,11 @@ def _result_to_full_dict(result: OptimizationResult, exercise: str) -> dict:
 def _emit_cli_summary(summary: dict) -> None:
     """Write the human-facing CLI summary to stdout.
 
-    This is the single intentional stdout path in `src/`, kept for the
-    command-line interface while operational events continue to use logging.
+    The CLI contract is a plain JSON payload on stdout, so this uses
+    ``sys.stdout.write`` instead of logging to avoid log prefixes that would
+    break downstream parsing.
     """
-    print(json.dumps(summary, indent=2))
+    sys.stdout.write(f"{json.dumps(summary, indent=2)}\n")
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -81,9 +81,9 @@ class TestResultSummary:
         assert full["arrays"]["t"] == result.t.tolist()
         assert full["arrays"]["bar"] == result.bar.tolist()
 
-    def test_emit_cli_summary_prints_json(self, monkeypatch: pytest.MonkeyPatch):
+    def test_emit_cli_summary_writes_json(self, monkeypatch: pytest.MonkeyPatch):
         lines: list[str] = []
-        monkeypatch.setattr("builtins.print", lambda text: lines.append(text))
+        monkeypatch.setattr(cli.sys.stdout, "write", lambda text: lines.append(text))
         _emit_cli_summary({"exercise": "squat", "success": True})
         assert len(lines) == 1
         assert json.loads(lines[0]) == {"exercise": "squat", "success": True}


### PR DESCRIPTION
## Summary
- replace the last src-level `print()` call with direct stdout JSON emission in the CLI
- keep the headless CLI JSON contract intact for downstream consumers
- refresh SPEC.md for the no-print cleanup

Closes #219