### PR TITLE
refactor: add public API to ProgressTracker (fixes #213)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -130,6 +130,7 @@ mypy --ignore-missing-imports src/movement_optimizer/
 
 | Date | Version | Changes |
 | --- | --- | --- |
+| 2026-04-11 | 1.0.3 | Added a stable public API to `ProgressTracker` (`cost_history`, `iteration_count`, `elapsed()`, `lock()`) and refactored `TrajectoryOptimizer` to stop reaching into its private attributes, eliminating a cluster of Law-of-Demeter violations in the optimiser engine. |
 | 2026-04-10 | 1.0.2 | Replaced the last `print()` call in `src/` with direct stdout JSON emission in the CLI summary path and updated the CLI regression test to preserve the headless output contract without violating the no-print rule. |
 | 2026-04-09 | 1.0.1 | Added a shared provider-pack manifest, validator, regression tests, and launcher icon asset so Movement-Optimizer can publish a launcher-compatible utility pack without embedding UpstreamDrift-specific path logic. |
 | 2026-04-06 | 1.0.0 | Initial repository specification aligned to the current package layout, entrypoints, and test contract. |

--- a/src/movement_optimizer/trajectory/optimizer.py
+++ b/src/movement_optimizer/trajectory/optimizer.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import logging
 import os
 import threading
-import time
 from collections.abc import Callable
 from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
 
@@ -120,7 +119,7 @@ class TrajectoryOptimizer:
         self._progress = ProgressTracker(progress_cb=progress_cb)
 
         # Kept for backward-compat (some callers read these directly)
-        self._progress_lock = self._progress._progress_lock
+        self._progress_lock = self._progress.lock()
 
     def _setup_time_grids(self) -> None:
         n_ctrl = self.n_waypoints + 2
@@ -290,16 +289,16 @@ class TrajectoryOptimizer:
 
     @property
     def _cost_history(self) -> list[float]:
-        return self._progress._cost_history
+        return self._progress.cost_history
 
     @_cost_history.setter
     def _cost_history(self, value: list[float]) -> None:
-        self._progress._cost_history = value
+        self._progress.cost_history = value
 
     def _detect_stall(self) -> tuple[bool, str]:
         from .optimizer_progress import detect_stall
 
-        return detect_stall(self._progress._cost_history)
+        return detect_stall(self._progress.cost_history)
 
     # ==========================================================
     # Initial guess generation (delegates to optimizer_guess)
@@ -433,7 +432,7 @@ class TrajectoryOptimizer:
             out = self._run_single_start_with_progress()
             if self.cancel_event.is_set():
                 raise CancelledError("Optimization cancelled by user")
-            elapsed = time.monotonic() - self._progress._start_time
+            elapsed = self._progress.elapsed()
             return self._package_results(out, elapsed)
         else:
             with ThreadPoolExecutor(max_workers=n_workers) as pool:
@@ -463,7 +462,7 @@ class TrajectoryOptimizer:
             raise CancelledError("All optimization starts were cancelled")
 
         best_res, _ = min(results, key=lambda r: float(r[0].fun))  # type: ignore[attr-defined]
-        elapsed = time.monotonic() - self._progress._start_time
+        elapsed = self._progress.elapsed()
         total_evals_sum = sum(n for _, n in results)
 
         logger.info(
@@ -558,6 +557,6 @@ class TrajectoryOptimizer:
             cost=cost_val,
             com_horizontal_range_cm=com_h_range,
             elapsed_s=elapsed,
-            n_evals=n_evals or self._progress._iter,
+            n_evals=n_evals or self._progress.iteration_count,
             n_joint_limit_violations=n_joint_limit_violations,
         )

--- a/src/movement_optimizer/trajectory/optimizer_progress.py
+++ b/src/movement_optimizer/trajectory/optimizer_progress.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import threading
 import time
+from contextlib import AbstractContextManager
 
 from .result import ProgressReport
 from .tuning import STALL_THRESHOLD, STALL_WINDOW
@@ -31,6 +32,37 @@ class ProgressTracker:
         self._best_cost: float = float("inf")
         self._start_time: float = 0.0
         self._progress_lock = threading.Lock()
+
+    # ------------------------------------------------------------------
+    # Public API (stable) — prefer these over touching private attributes.
+    # ------------------------------------------------------------------
+
+    @property
+    def cost_history(self) -> list[float]:
+        """Full cost history recorded so far (list, most recent last)."""
+        return self._cost_history
+
+    @cost_history.setter
+    def cost_history(self, value: list[float]) -> None:
+        """Replace the cost history (used by tests and diagnostics)."""
+        self._cost_history = value
+
+    @property
+    def iteration_count(self) -> int:
+        """Number of cost evaluations recorded."""
+        return self._iter
+
+    def elapsed(self) -> float:
+        """Seconds since the last :meth:`reset` call."""
+        return time.monotonic() - self._start_time
+
+    def lock(self) -> AbstractContextManager[bool]:
+        """Return the internal progress lock as a context manager.
+
+        Use this to synchronise external reads/writes with
+        :meth:`record_parallel`.
+        """
+        return self._progress_lock
 
     def reset(self) -> None:
         """Reset all mutable counters before a new optimisation run."""


### PR DESCRIPTION
## Summary
- Adds a stable public API to `ProgressTracker`: `cost_history` (get/set), `iteration_count`, `elapsed()`, and `lock()`.
- Refactors `TrajectoryOptimizer` so the 6 private-attribute reach-throughs flagged in #213 now go through the new public surface, improving encapsulation and Law of Demeter compliance.
- Drops a now-unused `import time` in `optimizer.py` and records the change in `SPEC.md`.

Fixes #213.

## Test plan
- [x] `python3 -m ruff check .`
- [x] `python3 -m ruff format --check .`
- [ ] `PYTHONPATH=src python3 -m pytest tests/test_trajectory.py -v` (existing stall-detection tests still drive `opt._cost_history`, which is now backed by the new public property)

Notes: kept the `_iter`, `_cost_history`, `_progress_lock`, and `_start_time` private attributes untouched for backward compatibility; the new public members are thin wrappers. The `self.dynamics.L` concern mentioned as an "Additionally" in the issue was not addressed here since it is a separate backend-interface change; this PR is scoped to the six ProgressTracker accesses called out in the issue title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)