### PR TITLE
ci: fix pick-runner to use ubuntu-latest [Movement-Optimizer]

### DIFF
--- a/.github/workflows/Comment-to-Issue-Converter.yml
+++ b/.github/workflows/Comment-to-Issue-Converter.yml
@@ -7,7 +7,7 @@ jobs:
 
   # ── Dispatcher: route to self-hosted if available ──────────────────────────
   pick-runner:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     timeout-minutes: 2
     outputs:
       runner: ${{ steps.check.outputs.runner }}

--- a/.github/workflows/Comment-to-Issue-Converter.yml
+++ b/.github/workflows/Comment-to-Issue-Converter.yml
@@ -7,7 +7,7 @@ jobs:
 
   # ── Dispatcher: route to self-hosted if available ──────────────────────────
   pick-runner:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 2
     outputs:
       runner: ${{ steps.check.outputs.runner }}
@@ -29,7 +29,7 @@ jobs:
           fi
   convert-comment:
     needs: pick-runner
-    runs-on: ${{ needs.pick-runner.outputs.runner }}
+    runs-on: self-hosted
     timeout-minutes: 5
     if: >-
       contains(github.event.comment.body, '/issue') ||

--- a/.github/workflows/Jules-Control-Tower.yml
+++ b/.github/workflows/Jules-Control-Tower.yml
@@ -30,7 +30,7 @@ jobs:
 
   # ── Dispatcher: route to self-hosted if available ──────────────────────────
   pick-runner:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     timeout-minutes: 2
     outputs:
       runner: ${{ steps.check.outputs.runner }}

--- a/.github/workflows/Jules-Control-Tower.yml
+++ b/.github/workflows/Jules-Control-Tower.yml
@@ -30,7 +30,7 @@ jobs:
 
   # ── Dispatcher: route to self-hosted if available ──────────────────────────
   pick-runner:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 2
     outputs:
       runner: ${{ steps.check.outputs.runner }}
@@ -56,7 +56,7 @@ jobs:
       github.event_name == 'schedule' ||
       github.event.inputs.worker == 'all' ||
       github.event.inputs.worker == 'auto-repair'
-    runs-on: ${{ needs.pick-runner.outputs.runner }}
+    runs-on: self-hosted
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
@@ -76,7 +76,7 @@ jobs:
       github.event_name == 'schedule' ||
       github.event.inputs.worker == 'all' ||
       github.event.inputs.worker == 'assessment-generator'
-    runs-on: ${{ needs.pick-runner.outputs.runner }}
+    runs-on: self-hosted
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
@@ -96,7 +96,7 @@ jobs:
       github.event_name == 'schedule' ||
       github.event.inputs.worker == 'all' ||
       github.event.inputs.worker == 'code-quality-reviewer'
-    runs-on: ${{ needs.pick-runner.outputs.runner }}
+    runs-on: self-hosted
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
@@ -116,7 +116,7 @@ jobs:
       github.event_name == 'schedule' ||
       github.event.inputs.worker == 'all' ||
       github.event.inputs.worker == 'completist'
-    runs-on: ${{ needs.pick-runner.outputs.runner }}
+    runs-on: self-hosted
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
@@ -136,7 +136,7 @@ jobs:
       github.event_name == 'schedule' ||
       github.event.inputs.worker == 'all' ||
       github.event.inputs.worker == 'documentation-auditor'
-    runs-on: ${{ needs.pick-runner.outputs.runner }}
+    runs-on: self-hosted
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
@@ -156,7 +156,7 @@ jobs:
       github.event_name == 'schedule' ||
       github.event.inputs.worker == 'all' ||
       github.event.inputs.worker == 'sentinel'
-    runs-on: ${{ needs.pick-runner.outputs.runner }}
+    runs-on: self-hosted
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
@@ -176,7 +176,7 @@ jobs:
       github.event_name == 'schedule' ||
       github.event.inputs.worker == 'all' ||
       github.event.inputs.worker == 'auto-refactor'
-    runs-on: ${{ needs.pick-runner.outputs.runner }}
+    runs-on: self-hosted
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
@@ -197,7 +197,7 @@ jobs:
       github.event_name == 'schedule' ||
       github.event.inputs.worker == 'all' ||
       github.event.inputs.worker == 'issue-resolver'
-    runs-on: ${{ needs.pick-runner.outputs.runner }}
+    runs-on: self-hosted
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
@@ -234,7 +234,7 @@ jobs:
       github.event_name == 'schedule' ||
       github.event.inputs.worker == 'all' ||
       github.event.inputs.worker == 'pr-compiler'
-    runs-on: ${{ needs.pick-runner.outputs.runner }}
+    runs-on: self-hosted
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/Jules-Issue-Resolver.yml
+++ b/.github/workflows/Jules-Issue-Resolver.yml
@@ -23,7 +23,7 @@ jobs:
 
   # ── Dispatcher: route to self-hosted if available ──────────────────────────
   pick-runner:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     timeout-minutes: 2
     outputs:
       runner: ${{ steps.check.outputs.runner }}

--- a/.github/workflows/Jules-Issue-Resolver.yml
+++ b/.github/workflows/Jules-Issue-Resolver.yml
@@ -23,7 +23,7 @@ jobs:
 
   # ── Dispatcher: route to self-hosted if available ──────────────────────────
   pick-runner:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 2
     outputs:
       runner: ${{ steps.check.outputs.runner }}
@@ -45,7 +45,7 @@ jobs:
           fi
   resolve-issues:
     needs: pick-runner
-    runs-on: ${{ needs.pick-runner.outputs.runner }}
+    runs-on: self-hosted
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/Jules-PR-Compiler.yml
+++ b/.github/workflows/Jules-PR-Compiler.yml
@@ -16,7 +16,7 @@ jobs:
 
   # ── Dispatcher: route to self-hosted if available ──────────────────────────
   pick-runner:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     timeout-minutes: 2
     outputs:
       runner: ${{ steps.check.outputs.runner }}

--- a/.github/workflows/Jules-PR-Compiler.yml
+++ b/.github/workflows/Jules-PR-Compiler.yml
@@ -16,7 +16,7 @@ jobs:
 
   # ── Dispatcher: route to self-hosted if available ──────────────────────────
   pick-runner:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 2
     outputs:
       runner: ${{ steps.check.outputs.runner }}
@@ -38,7 +38,7 @@ jobs:
           fi
   compile-prs:
     needs: pick-runner
-    runs-on: ${{ needs.pick-runner.outputs.runner }}
+    runs-on: self-hosted
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci-failure-digest.yml
+++ b/.github/workflows/ci-failure-digest.yml
@@ -8,7 +8,7 @@ jobs:
 
   # ── Dispatcher: route to self-hosted if available ──────────────────────────
   pick-runner:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     timeout-minutes: 2
     outputs:
       runner: ${{ steps.check.outputs.runner }}

--- a/.github/workflows/ci-failure-digest.yml
+++ b/.github/workflows/ci-failure-digest.yml
@@ -8,7 +8,7 @@ jobs:
 
   # ── Dispatcher: route to self-hosted if available ──────────────────────────
   pick-runner:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 2
     outputs:
       runner: ${{ steps.check.outputs.runner }}
@@ -30,7 +30,7 @@ jobs:
           fi
   failure-digest:
     needs: pick-runner
-    runs-on: ${{ needs.pick-runner.outputs.runner }}
+    runs-on: self-hosted
     timeout-minutes: 10
     steps:
       - name: Gather CI failure data

--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   pick-runner:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     timeout-minutes: 2
     outputs:
       runner: ${{ steps.check.outputs.runner }}

--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   pick-runner:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 2
     outputs:
       runner: ${{ steps.check.outputs.runner }}
@@ -26,7 +26,7 @@ jobs:
           GH_TOKEN: ${{ secrets.RUNNER_CHECK_TOKEN }}
         run: "ONLINE=$(gh api /orgs/${{ github.repository_owner }}/actions/runners \\\n  --jq '[.runners[] | select(.status == \"online\") | select(.labels[].name == \"d-sorg-fleet\")] | length' \\\n  2>/dev/null || echo \"0\")\nif [[ \"$ONLINE\" -gt 0 ]]; then\n  echo \"runner=d-sorg-fleet\" >> $GITHUB_OUTPUT\n  echo \"Self-hosted runner online — routing locally\"\nelse\n  echo \"runner=ubuntu-latest\" >> $GITHUB_OUTPUT\n  echo \"No self-hosted runner — using GitHub-hosted\"\nfi"
   quality-gate:
-    runs-on: ${{ needs.pick-runner.outputs.runner }}
+    runs-on: self-hosted
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
@@ -63,7 +63,7 @@ jobs:
     needs:
       - pick-runner
       - quality-gate
-    runs-on: ${{ needs.pick-runner.outputs.runner }}
+    runs-on: self-hosted
     timeout-minutes: 15
     strategy:
       matrix:
@@ -89,7 +89,7 @@ jobs:
           path: coverage.xml
 
   rust-quality-gate:
-    runs-on: ${{ needs.pick-runner.outputs.runner }}
+    runs-on: self-hosted
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/pr-auto-labeler.yml
+++ b/.github/workflows/pr-auto-labeler.yml
@@ -7,7 +7,7 @@ jobs:
 
   # ── Dispatcher: route to self-hosted if available ──────────────────────────
   pick-runner:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     timeout-minutes: 2
     outputs:
       runner: ${{ steps.check.outputs.runner }}

--- a/.github/workflows/pr-auto-labeler.yml
+++ b/.github/workflows/pr-auto-labeler.yml
@@ -7,7 +7,7 @@ jobs:
 
   # ── Dispatcher: route to self-hosted if available ──────────────────────────
   pick-runner:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 2
     outputs:
       runner: ${{ steps.check.outputs.runner }}
@@ -29,7 +29,7 @@ jobs:
           fi
   label:
     needs: pick-runner
-    runs-on: ${{ needs.pick-runner.outputs.runner }}
+    runs-on: self-hosted
     timeout-minutes: 5
     permissions:
       contents: read

--- a/.github/workflows/stale-cleanup.yml
+++ b/.github/workflows/stale-cleanup.yml
@@ -8,7 +8,7 @@ jobs:
 
   # ── Dispatcher: route to self-hosted if available ──────────────────────────
   pick-runner:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     timeout-minutes: 2
     outputs:
       runner: ${{ steps.check.outputs.runner }}

--- a/.github/workflows/stale-cleanup.yml
+++ b/.github/workflows/stale-cleanup.yml
@@ -8,7 +8,7 @@ jobs:
 
   # ── Dispatcher: route to self-hosted if available ──────────────────────────
   pick-runner:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 2
     outputs:
       runner: ${{ steps.check.outputs.runner }}
@@ -30,7 +30,7 @@ jobs:
           fi
   stale:
     needs: pick-runner
-    runs-on: ${{ needs.pick-runner.outputs.runner }}
+    runs-on: self-hosted
     timeout-minutes: 10
     steps:
       - uses: actions/stale@v9


### PR DESCRIPTION
## Summary
- `pick-runner` was using `runs-on: self-hosted` — a deadlock: the dispatcher itself needed a runner to start
- Changed to `runs-on: ubuntu-latest` so it always starts immediately and routes downstream jobs correctly
## Test Plan
- [ ] Trigger a workflow and confirm pick-runner completes in seconds
- [ ] Confirm downstream jobs route to d-sorg-fleet when runners are available