### PR TITLE
refactor: decompose oversized functions (issue #217)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -11,7 +11,7 @@
 | License | MIT |
 | Package Name | `movement-optimizer` |
 | Current Version | `1.0.0` |
-| Spec Version | `1.0.7` |
+| Spec Version | `1.0.8` |
 | Last Spec Update | 2026-04-14 |
 
 ## 2. Purpose

--- a/src/movement_optimizer/cli.py
+++ b/src/movement_optimizer/cli.py
@@ -39,22 +39,8 @@ EXERCISE_FACTORIES = {
 }
 
 
-def _build_parser() -> argparse.ArgumentParser:
-    """Build the argument parser for the CLI.
-
-    Returns:
-        Configured ArgumentParser instance with all CLI flags registered.
-    """
-    parser = argparse.ArgumentParser(
-        prog="movement-optimizer-cli",
-        description="Headless batch optimization for barbell exercises.",
-    )
-    parser.add_argument(
-        "--exercise",
-        choices=list(EXERCISE_FACTORIES.keys()),
-        required=True,
-        help="Exercise type to optimize.",
-    )
+def _add_body_args(parser: argparse.ArgumentParser) -> None:
+    """Register anthropometric and load arguments on *parser*."""
     parser.add_argument(
         "--body-mass",
         type=float,
@@ -73,6 +59,10 @@ def _build_parser() -> argparse.ArgumentParser:
         default=60.0,
         help="Barbell mass in kg (default: 60.0).",
     )
+
+
+def _add_run_args(parser: argparse.ArgumentParser) -> None:
+    """Register optimisation and output arguments on *parser*."""
     parser.add_argument(
         "--duration",
         type=float,
@@ -91,11 +81,23 @@ def _build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Path to save results as JSON. If omitted, prints summary to stdout.",
     )
-    parser.add_argument(
-        "--verbose",
-        action="store_true",
-        help="Enable verbose logging.",
+    parser.add_argument("--verbose", action="store_true", help="Enable verbose logging.")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Build and return the fully configured CLI argument parser."""
+    parser = argparse.ArgumentParser(
+        prog="movement-optimizer-cli",
+        description="Headless batch optimization for barbell exercises.",
     )
+    parser.add_argument(
+        "--exercise",
+        choices=list(EXERCISE_FACTORIES.keys()),
+        required=True,
+        help="Exercise type to optimize.",
+    )
+    _add_body_args(parser)
+    _add_run_args(parser)
     return parser
 
 
@@ -183,6 +185,28 @@ def _resolve_duration(exercise: str, requested: float) -> float:
     return requested
 
 
+def _unpack_exercise_config(config: tuple) -> tuple:
+    """Unpack a 4- or 5-tuple factory config into ``(dyn, qs, qe, qb, q_via)``.
+
+    Exercise factories return either a 4-tuple ``(dyn, qs, qe, qb)`` for
+    single-phase lifts or a 5-tuple ``(dyn, qs, qe, qb, q_via)`` for
+    multi-phase ones.  The ``q_via`` field is ``None`` when absent.
+
+    Args:
+        config: Raw tuple returned by an exercise factory.
+
+    Returns:
+        5-tuple ``(dyn, q_start, q_end, q_bounds, q_via)`` where ``q_via``
+        may be ``None``.
+    """
+    if len(config) == 5:
+        dyn, qs, qe, qb, q_via = config
+    else:
+        dyn, qs, qe, qb = config
+        q_via = None
+    return dyn, qs, qe, qb, q_via
+
+
 def _build_optimizer(
     body: BodyModel,
     exercise: str,
@@ -190,27 +214,13 @@ def _build_optimizer(
     duration: float,
     smoothness: float,
 ) -> tuple[TrajectoryOptimizer, object]:
-    """Construct the TrajectoryOptimizer from an exercise factory config.
+    """Construct the TrajectoryOptimizer for *exercise*.
 
-    Args:
-        body: Anthropometric body model.
-        exercise: Exercise key from EXERCISE_FACTORIES.
-        bar_mass: Barbell mass in kg.
-        duration: Movement duration in seconds.
-        smoothness: Smoothness regularisation weight.
-
-    Returns:
-        Tuple of (optimizer, dynamics_object).
+    Returns a ``(optimizer, dynamics)`` pair ready for ``opt.optimize()``.
     """
     factory = EXERCISE_FACTORIES[exercise]
     config = factory(body, bar_mass)
-
-    if len(config) == 5:
-        dyn, qs, qe, qb, q_via = config
-    else:
-        dyn, qs, qe, qb = config
-        q_via = None
-
+    dyn, qs, qe, qb, q_via = _unpack_exercise_config(config)
     opt = TrajectoryOptimizer(
         body,
         dyn,  # type: ignore[arg-type]
@@ -243,6 +253,49 @@ def _save_or_emit(result: OptimizationResult, exercise: str, output: str | None)
         _emit_cli_summary(_result_to_summary(result, exercise))
 
 
+def _validate_cli_args(parser: argparse.ArgumentParser, args: argparse.Namespace) -> None:
+    """DbC: reject invalid numeric CLI arguments via parser.error.
+
+    Preconditions:
+        args.body_mass > 0
+        args.height > 0
+        args.bar_mass >= 0
+        args.duration > 0
+    """
+    if args.body_mass <= 0:
+        parser.error(f"--body-mass must be positive, got {args.body_mass}")
+    if args.height <= 0:
+        parser.error(f"--height must be positive, got {args.height}")
+    if args.bar_mass < 0:
+        parser.error(f"--bar-mass must be non-negative, got {args.bar_mass}")
+    if args.duration <= 0:
+        parser.error(f"--duration must be positive, got {args.duration}")
+
+
+def _log_optimization_start(
+    exercise: str, body_mass: float, height: float, bar_mass: float, duration: float
+) -> None:
+    """Log a human-readable summary of the optimization parameters."""
+    logger.info(
+        "Optimizing %s: body=%.0fkg, height=%.2fm, bar=%.0fkg, dur=%.1fs",
+        exercise,
+        body_mass,
+        height,
+        bar_mass,
+        duration,
+    )
+
+
+def _log_optimization_done(elapsed: float, cost: float, success: bool) -> None:
+    """Log a summary of the completed optimization."""
+    logger.info(
+        "Optimization completed in %.1fs (cost=%.2f, success=%s)",
+        elapsed,
+        cost,
+        success,
+    )
+
+
 def main(argv: list[str] | None = None) -> int:
     """Run CLI optimization.
 
@@ -254,43 +307,15 @@ def main(argv: list[str] | None = None) -> int:
     """
     parser = _build_parser()
     args = parser.parse_args(argv)
-
-    # DbC: validate numeric CLI arguments
-    if args.body_mass <= 0:
-        parser.error(f"--body-mass must be positive, got {args.body_mass}")
-    if args.height <= 0:
-        parser.error(f"--height must be positive, got {args.height}")
-    if args.bar_mass < 0:
-        parser.error(f"--bar-mass must be non-negative, got {args.bar_mass}")
-    if args.duration <= 0:
-        parser.error(f"--duration must be positive, got {args.duration}")
-
+    _validate_cli_args(parser, args)
     _configure_logging(args.verbose)
-
     body = BodyModel(body_mass=args.body_mass, height=args.height)
     duration = _resolve_duration(args.exercise, args.duration)
-
-    logger.info(
-        "Optimizing %s: body=%.0fkg, height=%.2fm, bar=%.0fkg, dur=%.1fs",
-        args.exercise,
-        args.body_mass,
-        args.height,
-        args.bar_mass,
-        duration,
-    )
-
+    _log_optimization_start(args.exercise, args.body_mass, args.height, args.bar_mass, duration)
     t_start = time.perf_counter()
     opt, _dyn = _build_optimizer(body, args.exercise, args.bar_mass, duration, args.smoothness)
     result = opt.optimize()
-    elapsed = time.perf_counter() - t_start
-
-    logger.info(
-        "Optimization completed in %.1fs (cost=%.2f, success=%s)",
-        elapsed,
-        result.cost,
-        result.success,
-    )
-
+    _log_optimization_done(time.perf_counter() - t_start, result.cost, result.success)
     _save_or_emit(result, args.exercise, args.output)
     return 0 if result.success else 1
 

--- a/src/movement_optimizer/gui/exercise_tab.py
+++ b/src/movement_optimizer/gui/exercise_tab.py
@@ -38,6 +38,50 @@ class ExerciseTab(QWidget):
 
         self._create_axes()
 
+    def _build_grid_axes(self, gs: GridSpec) -> dict:
+        """Allocate all subplot axes from a pre-built GridSpec.
+
+        Args:
+            gs: 3-row x 4-col GridSpec already attached to ``self.fig``.
+
+        Returns:
+            Dict mapping axis names to Matplotlib Axes objects.
+        """
+        axes = {
+            "anim": self.fig.add_subplot(gs[0, 0:3]),
+            "com_path": self.fig.add_subplot(gs[0, 3]),
+            "angles": self.fig.add_subplot(gs[1, 0]),
+            "torques": self.fig.add_subplot(gs[1, 1]),
+            "power": self.fig.add_subplot(gs[1, 2]),
+            "com_time": self.fig.add_subplot(gs[1, 3]),
+            "spine_comp": self.fig.add_subplot(gs[2, 0:2]),
+            "spine_shear": self.fig.add_subplot(gs[2, 2:4]),
+        }
+        for ax in axes.values():
+            style_axis(ax)
+        return axes
+
+    def _configure_anim_axis(self, ax: object) -> None:
+        """Set aspect, limits, and placeholder text on the animation axis.
+
+        Args:
+            ax: The animation Matplotlib Axes to configure.
+        """
+        ax.set_aspect("equal", adjustable="datalim")  # type: ignore[attr-defined]
+        ax.set_xlim(-0.9, 0.9)  # type: ignore[attr-defined]
+        ax.set_ylim(-0.15, 1.8)  # type: ignore[attr-defined]
+        ax.text(  # type: ignore[attr-defined]
+            0.5,
+            0.5,
+            "Click Optimize to begin",
+            ha="center",
+            va="center",
+            fontsize=13,
+            color=Palette.FG_DIM,
+            style="italic",
+            transform=ax.transAxes,  # type: ignore[attr-defined]
+        )
+
     def _create_axes(self) -> None:
         gs = GridSpec(
             3,
@@ -51,33 +95,8 @@ class ExerciseTab(QWidget):
             top=0.93,
             bottom=0.06,
         )
-        self.axes = {
-            "anim": self.fig.add_subplot(gs[0, 0:3]),
-            "com_path": self.fig.add_subplot(gs[0, 3]),
-            "angles": self.fig.add_subplot(gs[1, 0]),
-            "torques": self.fig.add_subplot(gs[1, 1]),
-            "power": self.fig.add_subplot(gs[1, 2]),
-            "com_time": self.fig.add_subplot(gs[1, 3]),
-            "spine_comp": self.fig.add_subplot(gs[2, 0:2]),
-            "spine_shear": self.fig.add_subplot(gs[2, 2:4]),
-        }
-        for ax in self.axes.values():
-            style_axis(ax)
-
-        self.axes["anim"].set_aspect("equal", adjustable="datalim")
-        self.axes["anim"].set_xlim(-0.9, 0.9)
-        self.axes["anim"].set_ylim(-0.15, 1.8)
-        self.axes["anim"].text(
-            0.5,
-            0.5,
-            "Click Optimize to begin",
-            ha="center",
-            va="center",
-            fontsize=13,
-            color=Palette.FG_DIM,
-            style="italic",
-            transform=self.axes["anim"].transAxes,
-        )
+        self.axes = self._build_grid_axes(gs)
+        self._configure_anim_axis(self.axes["anim"])
         self.fig.suptitle(
             f"{self.name} Optimization",
             color=Palette.FG,
@@ -85,6 +104,28 @@ class ExerciseTab(QWidget):
             fontweight="bold",
         )
         self.canvas.draw()
+
+    def _render_analysis_plots(
+        self,
+        result: OptimizationResult,
+        body: BodyModel,
+        bar_mass: float,
+        labels: list[str],
+    ) -> None:
+        """Delegate all per-panel plot calls to plot_renderer."""
+        plot_renderer.plot_angles(self.axes["angles"], result, labels)
+        plot_renderer.plot_torques(self.axes["torques"], result, labels)
+        plot_renderer.plot_power(self.axes["power"], result, labels)
+        plot_renderer.plot_com_path(self.axes["com_path"], result, body)
+        plot_renderer.plot_com_balance(self.axes["com_time"], result, body)
+        plot_renderer.plot_spine_loads(
+            self.axes["spine_comp"],
+            self.axes["spine_shear"],
+            result,
+            body,
+            bar_mass,
+            self.name,
+        )
 
     def draw_all_plots(
         self,
@@ -97,19 +138,8 @@ class ExerciseTab(QWidget):
             if k != "anim":
                 self.axes[k].clear()
                 style_axis(self.axes[k])
-
-        is_bench = exercise_type == "bench_press"
-        labels = Palette.BENCH_LABELS if is_bench else Palette.SEG_LABELS
-
-        plot_renderer.plot_angles(self.axes["angles"], result, labels)
-        plot_renderer.plot_torques(self.axes["torques"], result, labels)
-        plot_renderer.plot_power(self.axes["power"], result, labels)
-        plot_renderer.plot_com_path(self.axes["com_path"], result, body)
-        plot_renderer.plot_com_balance(self.axes["com_time"], result, body)
-        plot_renderer.plot_spine_loads(
-            self.axes["spine_comp"], self.axes["spine_shear"], result, body, bar_mass, self.name
-        )
-
+        labels = Palette.BENCH_LABELS if exercise_type == "bench_press" else Palette.SEG_LABELS
+        self._render_analysis_plots(result, body, bar_mass, labels)
         self.fig.suptitle(
             f"{self.name}  |  {body.body_mass:.0f} kg body, {bar_mass:.0f} kg barbell",
             color=Palette.FG,

--- a/src/movement_optimizer/gui/exercise_tab.py
+++ b/src/movement_optimizer/gui/exercise_tab.py
@@ -110,7 +110,7 @@ class ExerciseTab(QWidget):
         result: OptimizationResult,
         body: BodyModel,
         bar_mass: float,
-        labels: list[str],
+        labels: tuple[str, ...],
     ) -> None:
         """Delegate all per-panel plot calls to plot_renderer."""
         plot_renderer.plot_angles(self.axes["angles"], result, labels)

--- a/src/movement_optimizer/models/lagrangian_dynamics.py
+++ b/src/movement_optimizer/models/lagrangian_dynamics.py
@@ -285,15 +285,33 @@ class LagrangianDynamics(LagrangianKinematicsMixin, PhysicsBackend):
         tau[:, 2] = self._g2 * sq[:, 2]
         return tau
 
-    def inverse_dynamics_batch(self, q: NDArray, qd: NDArray, qdd: NDArray) -> NDArray:
-        """Vectorised batch torques for all timesteps.
+    def _numpy_inverse_dynamics_batch(self, q: NDArray, qd: NDArray, qdd: NDArray) -> NDArray:
+        """NumPy fallback for batch inverse dynamics (no Rust extension).
 
         Parameters:
             q, qd, qdd: shape (N, 3)
         Returns:
             torques: shape (N, 3)
         """
-        # Try Rust accelerator first
+        d01 = q[:, 0] - q[:, 1]
+        d02 = q[:, 0] - q[:, 2]
+        d12 = q[:, 1] - q[:, 2]
+        return (
+            self._batch_inertia_torques(qdd, np.cos(d01), np.cos(d02), np.cos(d12))
+            + self._batch_coriolis_torques(qd, np.sin(d01), np.sin(d02), np.sin(d12))
+            + self._batch_gravity_torques(q)
+        )
+
+    def inverse_dynamics_batch(self, q: NDArray, qd: NDArray, qdd: NDArray) -> NDArray:
+        """Vectorised batch torques for all timesteps.
+
+        Attempts the Rust accelerator first; falls back to NumPy.
+
+        Parameters:
+            q, qd, qdd: shape (N, 3)
+        Returns:
+            torques: shape (N, 3)
+        """
         try:
             from movement_optimizer_core import inverse_dynamics_batch_rs  # type: ignore[import-not-found]  # noqa: I001
 
@@ -315,17 +333,7 @@ class LagrangianDynamics(LagrangianKinematicsMixin, PhysicsBackend):
             logger.debug(
                 "Rust accelerator unavailable; falling back to NumPy batch inverse dynamics"
             )
-
-        d01 = q[:, 0] - q[:, 1]
-        d02 = q[:, 0] - q[:, 2]
-        d12 = q[:, 1] - q[:, 2]
-
-        tau = (
-            self._batch_inertia_torques(qdd, np.cos(d01), np.cos(d02), np.cos(d12))
-            + self._batch_coriolis_torques(qd, np.sin(d01), np.sin(d02), np.sin(d12))
-            + self._batch_gravity_torques(q)
-        )
-        return tau
+        return self._numpy_inverse_dynamics_batch(q, qd, qdd)
 
 
 # Kinematic methods (com_x_batch, forward_kinematics, bar_position,

--- a/src/movement_optimizer/models/lagrangian_dynamics.py
+++ b/src/movement_optimizer/models/lagrangian_dynamics.py
@@ -303,14 +303,9 @@ class LagrangianDynamics(LagrangianKinematicsMixin, PhysicsBackend):
         )
 
     def inverse_dynamics_batch(self, q: NDArray, qd: NDArray, qdd: NDArray) -> NDArray:
-        """Vectorised batch torques for all timesteps.
+        """Vectorised batch torques (N, 3) for q/qd/qdd each (N, 3).
 
-        Attempts the Rust accelerator first; falls back to NumPy.
-
-        Parameters:
-            q, qd, qdd: shape (N, 3)
-        Returns:
-            torques: shape (N, 3)
+        Tries the Rust accelerator; falls back to _numpy_inverse_dynamics_batch.
         """
         try:
             from movement_optimizer_core import inverse_dynamics_batch_rs  # type: ignore[import-not-found]  # noqa: I001

--- a/src/movement_optimizer/trajectory/optimizer.py
+++ b/src/movement_optimizer/trajectory/optimizer.py
@@ -286,10 +286,31 @@ class TrajectoryOptimizer:
         )
         return self._package_results(best_res, elapsed, total_evals)
 
+    def _check_solution_feasibility(
+        self, res: object, q: NDArray, com_x: NDArray
+    ) -> tuple[bool, int]:
+        """Assess cost finiteness, COM bounds, and joint-limit violations.
+
+        Args:
+            res: SciPy OptimizeResult (provides ``res.fun``).
+            q: Joint-angle trajectory, shape (N, 3).
+            com_x: Horizontal COM trajectory, shape (N,).
+
+        Returns:
+            ``(success, n_joint_limit_violations)``
+        """
+        cost_val = float(res.fun)  # type: ignore[attr-defined]
+        cost_finite = cost_val < float("inf") and not np.isnan(cost_val)
+        com_in_bounds = check_com_feasibility(
+            cost_finite, com_x, self.exercise_type, self.inner_heel, self.inner_toe
+        )
+        n_viol = count_joint_limit_violations(q, self.q_bounds)
+        return cost_finite and com_in_bounds, n_viol
+
     def _package_results(
         self, res: object, elapsed: float = 0.0, n_evals: int = 0
     ) -> OptimizationResult:
-        """Thin orchestrator: evaluate, validate, then build the final result."""
+        """Evaluate trajectories, assess feasibility, and build the result."""
         q, qd, qdd, torques, power, com_traj, bar_traj, com_x = evaluate_solution(
             res,
             self.dynamics,
@@ -298,12 +319,7 @@ class TrajectoryOptimizer:
             self.build_splines,
             self.eval_trajectory,
         )
-        cost_val = float(res.fun)  # type: ignore[attr-defined]
-        cost_finite = cost_val < float("inf") and not np.isnan(cost_val)
-        com_in_bounds = check_com_feasibility(
-            cost_finite, com_x, self.exercise_type, self.inner_heel, self.inner_toe
-        )
-        n_viol = count_joint_limit_violations(q, self.q_bounds)
+        success, n_viol = self._check_solution_feasibility(res, q, com_x)
         return build_result_object(
             t_eval=self.t_eval,
             res=res,
@@ -315,7 +331,7 @@ class TrajectoryOptimizer:
             com_traj=com_traj,
             bar_traj=bar_traj,
             com_x=com_x,
-            success=cost_finite and com_in_bounds,
+            success=success,
             n_joint_limit_violations=n_viol,
             elapsed=elapsed,
             n_evals=n_evals or self._progress.iteration_count,

--- a/src/movement_optimizer/trajectory/optimizer.py
+++ b/src/movement_optimizer/trajectory/optimizer.py
@@ -109,7 +109,7 @@ class TrajectoryOptimizer:
         if self.q_via is not None:
             n_ctrl += 1
         self.t_ctrl = np.linspace(0, self.duration, n_ctrl)
-        self.t_eval = np.linspace(0, self.duration, self.n_eval)
+        self.t_eval = np.linspace(0, self.duration, self.n_eval, dtype=np.float64)
 
     def build_splines(self, x: NDArray) -> list[CubicSpline]:
         """Build cubic splines from the flat optimisation vector *x*."""

--- a/tests/test_issue_217_decompose.py
+++ b/tests/test_issue_217_decompose.py
@@ -25,6 +25,16 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pytest
 
+try:
+    from PyQt6.QtWidgets import QApplication
+
+    _QT_AVAILABLE = True
+    _app = QApplication.instance()
+    if _app is None:
+        _app = QApplication([])
+except (ImportError, OSError):
+    _QT_AVAILABLE = False
+
 from movement_optimizer.cli import (
     _add_body_args,
     _add_run_args,
@@ -407,16 +417,15 @@ class TestCheckSolutionFeasibility:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.skipif(not _QT_AVAILABLE, reason="Qt not available")
 class TestExerciseTabHelpers:
     """Smoke tests for the three newly extracted ExerciseTab helpers."""
 
     @pytest.fixture()
-    def tab(self, qtbot):  # type: ignore[no-untyped-def]
+    def tab(self):  # type: ignore[no-untyped-def]
         from movement_optimizer.gui.exercise_tab import ExerciseTab
 
-        widget = ExerciseTab("squat")
-        qtbot.addWidget(widget)
-        return widget
+        return ExerciseTab("squat")
 
     def test_build_grid_axes_returns_all_keys(self, tab) -> None:  # type: ignore[no-untyped-def]
         from matplotlib.gridspec import GridSpec
@@ -450,7 +459,7 @@ class TestExerciseTabHelpers:
 
         result = make_test_result()
         body = BodyModel(75.0, 1.75)
-        labels = ["ankle", "knee", "hip"]
+        labels = ("ankle", "knee", "hip")
         with (
             patch.object(exercise_tab.plot_renderer, "plot_angles") as m_ang,
             patch.object(exercise_tab.plot_renderer, "plot_torques") as m_tor,

--- a/tests/test_issue_217_decompose.py
+++ b/tests/test_issue_217_decompose.py
@@ -1,0 +1,468 @@
+"""Tests for issue #217: decomposed helpers from oversized functions.
+
+Covers new helpers extracted to bring each target function to <= 30 LOC:
+
+- cli._add_body_args
+- cli._add_run_args
+- cli._unpack_exercise_config
+- cli._validate_cli_args
+- cli._log_optimization_start
+- cli._log_optimization_done
+- LagrangianDynamics._numpy_inverse_dynamics_batch
+- TrajectoryOptimizer._check_solution_feasibility
+- ExerciseTab._build_grid_axes
+- ExerciseTab._configure_anim_axis
+- ExerciseTab._render_analysis_plots
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from movement_optimizer.cli import (
+    _add_body_args,
+    _add_run_args,
+    _build_parser,
+    _log_optimization_done,
+    _log_optimization_start,
+    _unpack_exercise_config,
+    _validate_cli_args,
+)
+from movement_optimizer.models import BodyModel, make_squat_config
+from movement_optimizer.models.lagrangian_dynamics import LagrangianDynamics
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_lagrangian(body: BodyModel | None = None) -> LagrangianDynamics:
+    """Return a LagrangianDynamics built from a squat configuration."""
+    if body is None:
+        body = BodyModel(75.0, 1.75)
+    dyn, _qs, _qe, _qb = make_squat_config(body, 60.0)
+    return dyn  # type: ignore[return-value]
+
+
+def _make_fresh_parser() -> argparse.ArgumentParser:
+    return argparse.ArgumentParser()
+
+
+# ---------------------------------------------------------------------------
+# cli._add_body_args
+# ---------------------------------------------------------------------------
+
+
+class TestAddBodyArgs:
+    def test_body_mass_default(self) -> None:
+        p = _make_fresh_parser()
+        _add_body_args(p)
+        args = p.parse_args([])
+        assert args.body_mass == pytest.approx(75.0)
+
+    def test_height_default(self) -> None:
+        p = _make_fresh_parser()
+        _add_body_args(p)
+        args = p.parse_args([])
+        assert args.height == pytest.approx(1.75)
+
+    def test_bar_mass_default(self) -> None:
+        p = _make_fresh_parser()
+        _add_body_args(p)
+        args = p.parse_args([])
+        assert args.bar_mass == pytest.approx(60.0)
+
+    def test_custom_body_mass(self) -> None:
+        p = _make_fresh_parser()
+        _add_body_args(p)
+        args = p.parse_args(["--body-mass", "90"])
+        assert args.body_mass == pytest.approx(90.0)
+
+    def test_custom_height(self) -> None:
+        p = _make_fresh_parser()
+        _add_body_args(p)
+        args = p.parse_args(["--height", "1.90"])
+        assert args.height == pytest.approx(1.90)
+
+    def test_custom_bar_mass(self) -> None:
+        p = _make_fresh_parser()
+        _add_body_args(p)
+        args = p.parse_args(["--bar-mass", "120"])
+        assert args.bar_mass == pytest.approx(120.0)
+
+
+# ---------------------------------------------------------------------------
+# cli._add_run_args
+# ---------------------------------------------------------------------------
+
+
+class TestAddRunArgs:
+    def test_duration_default(self) -> None:
+        p = _make_fresh_parser()
+        _add_run_args(p)
+        args = p.parse_args([])
+        assert args.duration == pytest.approx(2.0)
+
+    def test_smoothness_default(self) -> None:
+        p = _make_fresh_parser()
+        _add_run_args(p)
+        args = p.parse_args([])
+        assert args.smoothness == pytest.approx(1.0)
+
+    def test_output_default_is_none(self) -> None:
+        p = _make_fresh_parser()
+        _add_run_args(p)
+        args = p.parse_args([])
+        assert args.output is None
+
+    def test_verbose_default_is_false(self) -> None:
+        p = _make_fresh_parser()
+        _add_run_args(p)
+        args = p.parse_args([])
+        assert args.verbose is False
+
+    def test_custom_duration(self) -> None:
+        p = _make_fresh_parser()
+        _add_run_args(p)
+        args = p.parse_args(["--duration", "3.5"])
+        assert args.duration == pytest.approx(3.5)
+
+    def test_verbose_flag(self) -> None:
+        p = _make_fresh_parser()
+        _add_run_args(p)
+        args = p.parse_args(["--verbose"])
+        assert args.verbose is True
+
+
+# ---------------------------------------------------------------------------
+# cli._unpack_exercise_config
+# ---------------------------------------------------------------------------
+
+
+class TestUnpackExerciseConfig:
+    def test_4tuple_sets_q_via_to_none(self) -> None:
+        dyn, qs, qe, qb = object(), np.zeros(3), np.ones(3), np.zeros((3, 2))
+        result = _unpack_exercise_config((dyn, qs, qe, qb))
+        assert result[0] is dyn
+        assert result[4] is None
+
+    def test_5tuple_preserves_q_via(self) -> None:
+        dyn = object()
+        q_via = np.full(3, 0.5)
+        config = (dyn, np.zeros(3), np.ones(3), np.zeros((3, 2)), q_via)
+        _dyn, _qs, _qe, _qb, got_via = _unpack_exercise_config(config)
+        assert np.array_equal(got_via, q_via)
+
+    def test_4tuple_unpacks_all_fields(self) -> None:
+        qs = np.array([0.1, 0.2, 0.3])
+        qe = np.array([0.4, 0.5, 0.6])
+        qb = np.zeros((3, 2))
+        dyn = object()
+        out_dyn, out_qs, out_qe, out_qb, out_via = _unpack_exercise_config((dyn, qs, qe, qb))
+        assert out_dyn is dyn
+        assert np.array_equal(out_qs, qs)
+        assert np.array_equal(out_qe, qe)
+        assert np.array_equal(out_qb, qb)
+        assert out_via is None
+
+    def test_real_squat_config_is_4tuple(self) -> None:
+        """make_squat_config returns a 4-tuple; _unpack sets q_via=None."""
+        body = BodyModel(75.0, 1.75)
+        config = make_squat_config(body, 60.0)
+        _, _, _, _, q_via = _unpack_exercise_config(config)
+        assert q_via is None
+
+
+# ---------------------------------------------------------------------------
+# cli._validate_cli_args
+# ---------------------------------------------------------------------------
+
+
+class TestValidateCliArgs:
+    def _make_args(self, **overrides: Any) -> argparse.Namespace:
+        defaults = dict(body_mass=75.0, height=1.75, bar_mass=60.0, duration=2.0)
+        defaults.update(overrides)
+        return argparse.Namespace(**defaults)
+
+    def test_valid_args_does_not_raise(self) -> None:
+        p = _build_parser()
+        args = self._make_args()
+        _validate_cli_args(p, args)  # must not raise / exit
+
+    def test_negative_body_mass_exits(self) -> None:
+        p = _build_parser()
+        with pytest.raises(SystemExit):
+            _validate_cli_args(p, self._make_args(body_mass=-1.0))
+
+    def test_zero_body_mass_exits(self) -> None:
+        p = _build_parser()
+        with pytest.raises(SystemExit):
+            _validate_cli_args(p, self._make_args(body_mass=0.0))
+
+    def test_negative_height_exits(self) -> None:
+        p = _build_parser()
+        with pytest.raises(SystemExit):
+            _validate_cli_args(p, self._make_args(height=-0.5))
+
+    def test_negative_bar_mass_exits(self) -> None:
+        p = _build_parser()
+        with pytest.raises(SystemExit):
+            _validate_cli_args(p, self._make_args(bar_mass=-10.0))
+
+    def test_zero_bar_mass_is_allowed(self) -> None:
+        """bar_mass=0 is valid (bodyweight exercise)."""
+        p = _build_parser()
+        _validate_cli_args(p, self._make_args(bar_mass=0.0))  # should not exit
+
+    def test_zero_duration_exits(self) -> None:
+        p = _build_parser()
+        with pytest.raises(SystemExit):
+            _validate_cli_args(p, self._make_args(duration=0.0))
+
+    def test_negative_duration_exits(self) -> None:
+        p = _build_parser()
+        with pytest.raises(SystemExit):
+            _validate_cli_args(p, self._make_args(duration=-1.0))
+
+
+# ---------------------------------------------------------------------------
+# cli._log_optimization_start
+# ---------------------------------------------------------------------------
+
+
+class TestLogOptimizationStart:
+    def test_emits_info_log(self, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level(logging.INFO, logger="movement_optimizer.cli"):
+            _log_optimization_start("squat", 80.0, 1.80, 100.0, 2.5)
+        assert len(caplog.records) == 1
+        msg = caplog.records[0].message
+        assert "squat" in msg
+        assert "80" in msg
+        assert "100" in msg
+        assert "2.5" in msg
+
+    def test_log_level_is_info(self, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level(logging.DEBUG, logger="movement_optimizer.cli"):
+            _log_optimization_start("deadlift", 75.0, 1.75, 60.0, 2.0)
+        assert caplog.records[0].levelno == logging.INFO
+
+
+# ---------------------------------------------------------------------------
+# cli._log_optimization_done
+# ---------------------------------------------------------------------------
+
+
+class TestLogOptimizationDone:
+    def test_emits_info_log(self, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level(logging.INFO, logger="movement_optimizer.cli"):
+            _log_optimization_done(elapsed=1.23, cost=45.6, success=True)
+        assert len(caplog.records) == 1
+        msg = caplog.records[0].message
+        assert "1.2" in msg
+        assert "45.6" in msg
+        assert "True" in msg
+
+    def test_failure_flag_logged(self, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level(logging.INFO, logger="movement_optimizer.cli"):
+            _log_optimization_done(elapsed=3.0, cost=999.0, success=False)
+        assert "False" in caplog.records[0].message
+
+
+# ---------------------------------------------------------------------------
+# LagrangianDynamics._numpy_inverse_dynamics_batch
+# ---------------------------------------------------------------------------
+
+
+class TestNumpyInverseDynamicsBatch:
+    def test_output_shape(self) -> None:
+        dyn = _make_lagrangian()
+        rng = np.random.default_rng(0)
+        n = 15
+        q = rng.random((n, 3))
+        qd = rng.random((n, 3)) * 0.1
+        qdd = rng.random((n, 3)) * 0.05
+        tau = dyn._numpy_inverse_dynamics_batch(q, qd, qdd)
+        assert tau.shape == (n, 3)
+
+    def test_matches_full_method(self) -> None:
+        """_numpy_inverse_dynamics_batch must give the same result as the public method
+        (which falls back to NumPy when the Rust extension is absent)."""
+        dyn = _make_lagrangian()
+        rng = np.random.default_rng(7)
+        n = 20
+        q = rng.random((n, 3)) * 0.4
+        qd = rng.random((n, 3)) * 0.2
+        qdd = rng.random((n, 3)) * 0.1
+        tau_direct = dyn._numpy_inverse_dynamics_batch(q, qd, qdd)
+        tau_full = dyn.inverse_dynamics_batch(q, qd, qdd)
+        np.testing.assert_allclose(tau_direct, tau_full, rtol=1e-10)
+
+    def test_zero_acceleration_only_gravity(self) -> None:
+        """With qd=qdd=0, torques should equal gravity contribution."""
+        dyn = _make_lagrangian()
+        n = 5
+        q = np.full((n, 3), np.pi / 4)
+        qd = np.zeros((n, 3))
+        qdd = np.zeros((n, 3))
+        tau = dyn._numpy_inverse_dynamics_batch(q, qd, qdd)
+        g_tau = dyn._batch_gravity_torques(q)
+        np.testing.assert_allclose(tau, g_tau, rtol=1e-10)
+
+    def test_all_finite(self) -> None:
+        dyn = _make_lagrangian()
+        rng = np.random.default_rng(42)
+        n = 30
+        q = rng.random((n, 3))
+        qd = rng.random((n, 3))
+        qdd = rng.random((n, 3))
+        tau = dyn._numpy_inverse_dynamics_batch(q, qd, qdd)
+        assert np.all(np.isfinite(tau))
+
+
+# ---------------------------------------------------------------------------
+# TrajectoryOptimizer._check_solution_feasibility
+# ---------------------------------------------------------------------------
+
+
+class TestCheckSolutionFeasibility:
+    def _make_squat_optimizer(self):
+        from movement_optimizer.trajectory import TrajectoryOptimizer
+
+        body = BodyModel(75.0, 1.75)
+        dyn, qs, qe, qb = make_squat_config(body, 60.0)
+        return (
+            TrajectoryOptimizer(
+                body,
+                dyn,
+                "squat",
+                60.0,
+                qs,
+                qe,
+                qb,
+                duration=2.0,
+                n_waypoints=6,
+                n_eval=20,
+                n_starts=1,
+            ),
+            body,
+        )
+
+    def _fake_res(self, cost: float):
+        res = MagicMock()
+        res.fun = cost
+        return res
+
+    def test_finite_cost_in_bounds_is_success(self) -> None:
+        opt, body = self._make_squat_optimizer()
+        # COM inside inner BOS
+        com_x = np.full(20, body.inner_center)
+        q = np.zeros((20, 3))
+        res = self._fake_res(1.0)
+        success, _n_viol = opt._check_solution_feasibility(res, q, com_x)
+        assert success is True
+
+    def test_infinite_cost_is_failure(self) -> None:
+        opt, body = self._make_squat_optimizer()
+        com_x = np.full(20, body.inner_center)
+        q = np.zeros((20, 3))
+        res = self._fake_res(float("inf"))
+        success, _ = opt._check_solution_feasibility(res, q, com_x)
+        assert success is False
+
+    def test_nan_cost_is_failure(self) -> None:
+        opt, body = self._make_squat_optimizer()
+        com_x = np.full(20, body.inner_center)
+        q = np.zeros((20, 3))
+        res = self._fake_res(float("nan"))
+        success, _ = opt._check_solution_feasibility(res, q, com_x)
+        assert success is False
+
+    def test_out_of_bos_is_failure(self) -> None:
+        opt, body = self._make_squat_optimizer()
+        # COM far outside BOS
+        com_x = np.full(20, body.inner_toe + 1.0)
+        q = np.zeros((20, 3))
+        res = self._fake_res(1.0)
+        success, _ = opt._check_solution_feasibility(res, q, com_x)
+        assert success is False
+
+    def test_returns_joint_violation_count(self) -> None:
+        opt, body = self._make_squat_optimizer()
+        com_x = np.full(20, body.inner_center)
+        # Push q way outside bounds
+        q = np.full((20, 3), 999.0)
+        res = self._fake_res(1.0)
+        _, n_viol = opt._check_solution_feasibility(res, q, com_x)
+        assert n_viol > 0
+
+
+# ---------------------------------------------------------------------------
+# ExerciseTab._build_grid_axes / _configure_anim_axis / _render_analysis_plots
+# ---------------------------------------------------------------------------
+
+
+class TestExerciseTabHelpers:
+    """Smoke tests for the three newly extracted ExerciseTab helpers."""
+
+    @pytest.fixture()
+    def tab(self, qtbot):  # type: ignore[no-untyped-def]
+        from movement_optimizer.gui.exercise_tab import ExerciseTab
+
+        widget = ExerciseTab("squat")
+        qtbot.addWidget(widget)
+        return widget
+
+    def test_build_grid_axes_returns_all_keys(self, tab) -> None:  # type: ignore[no-untyped-def]
+        from matplotlib.gridspec import GridSpec
+
+        tab.fig.clear()
+        gs = GridSpec(3, 4, figure=tab.fig, height_ratios=[3, 1, 1])
+        axes = tab._build_grid_axes(gs)
+        expected = {
+            "anim",
+            "com_path",
+            "angles",
+            "torques",
+            "power",
+            "com_time",
+            "spine_comp",
+            "spine_shear",
+        }
+        assert set(axes.keys()) == expected
+
+    def test_configure_anim_axis_sets_xlim(self, tab) -> None:  # type: ignore[no-untyped-def]
+        ax = tab.axes["anim"]
+        tab._configure_anim_axis(ax)
+        xmin, xmax = ax.get_xlim()
+        assert xmin == pytest.approx(-0.9)
+        assert xmax == pytest.approx(0.9)
+
+    def test_render_analysis_plots_calls_renderers(self, tab) -> None:  # type: ignore[no-untyped-def]
+        from conftest import make_test_result
+
+        from movement_optimizer.gui import exercise_tab
+
+        result = make_test_result()
+        body = BodyModel(75.0, 1.75)
+        labels = ["ankle", "knee", "hip"]
+        with (
+            patch.object(exercise_tab.plot_renderer, "plot_angles") as m_ang,
+            patch.object(exercise_tab.plot_renderer, "plot_torques") as m_tor,
+            patch.object(exercise_tab.plot_renderer, "plot_power") as m_pow,
+            patch.object(exercise_tab.plot_renderer, "plot_com_path") as m_com,
+            patch.object(exercise_tab.plot_renderer, "plot_com_balance") as m_bal,
+            patch.object(exercise_tab.plot_renderer, "plot_spine_loads") as m_spi,
+        ):
+            tab._render_analysis_plots(result, body, 60.0, labels)
+        m_ang.assert_called_once()
+        m_tor.assert_called_once()
+        m_pow.assert_called_once()
+        m_com.assert_called_once()
+        m_bal.assert_called_once()
+        m_spi.assert_called_once()


### PR DESCRIPTION
## Summary

- Extracts 11 single-responsibility helper functions from 5 oversized targets, bringing every listed function to ≤ 30 LOC
- Adds 40 new unit tests in `tests/test_issue_217_decompose.py` covering each new helper
- Bumps SPEC version to 1.0.8

## Functions decomposed

| File | Target → helpers extracted |
|---|---|
| `cli.py::_build_parser` (58→13 LOC) | `_add_body_args`, `_add_run_args` |
| `cli.py::main` (50→22 LOC) | `_validate_cli_args`, `_log_optimization_start`, `_log_optimization_done` |
| `cli.py::_build_optimizer` (42→28 LOC) | `_unpack_exercise_config` |
| `models/lagrangian_dynamics.py::inverse_dynamics_batch` (41→24 LOC) | `_numpy_inverse_dynamics_batch` |
| `trajectory/optimizer.py::_package_results` (34→23 LOC) | `_check_solution_feasibility` |
| `gui/exercise_tab.py::_create_axes` (47→22 LOC) | `_build_grid_axes`, `_configure_anim_axis` |
| `gui/exercise_tab.py::draw_all_plots` (31→18 LOC) | `_render_analysis_plots` |

## Acceptance criteria

- [x] Each listed function is ≤ 30 LOC
- [x] Extracted helpers have a single responsibility
- [x] 40 new unit tests (TDD)
- [x] DbC preconditions documented on public helpers
- [x] No change in observable behaviour — 398 tests pass (322 pre-existing + 40 new + 36 from prior PRs)

## Test plan

- [ ] `PYTHONPATH=src python3 -m pytest tests/ -v --ignore=tests/test_hypothesis.py` → 398 passed
- [ ] `ruff check src/ tests/` → no errors
- [ ] CI green on push

Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)