### PR TITLE
[codex] Reject non-finite HillTorqueModel parameters

### DIFF
--- a/src/movement_optimizer/strength.py
+++ b/src/movement_optimizer/strength.py
@@ -20,6 +20,11 @@ from .constants import (
 )
 
 
+def _require_finite(name: str, value: float) -> None:
+    if not np.isfinite(value):
+        raise ValueError(f"{name} must be finite")
+
+
 class HillTorqueModel:
     """Hill-type torque-angle-velocity model for a joint."""
 
@@ -33,6 +38,16 @@ class HillTorqueModel:
         ecc_factor: float = HILL_ECCENTRIC_FACTOR,
         max_ecc_ratio: float = HILL_MAX_ECCENTRIC_RATIO,
     ) -> None:
+        for name, value in (
+            ("tau_max", tau_max),
+            ("q_optimal", q_optimal),
+            ("angle_width", angle_width),
+            ("v_max", v_max),
+            ("k_shape", k_shape),
+            ("ecc_factor", ecc_factor),
+            ("max_ecc_ratio", max_ecc_ratio),
+        ):
+            _require_finite(name, value)
         if tau_max <= 0:
             raise ValueError("tau_max must be positive")
         if angle_width <= 0:
@@ -115,6 +130,7 @@ class JointTorqueSet:
         """Update the maximum isometric torque for a joint."""
         if joint_name not in self._models:
             raise ValueError(f"Unknown joint: {joint_name}")
+        _require_finite("tau_max", tau_max)
         if tau_max <= 0:
             raise ValueError("tau_max must be positive")
         self._models[joint_name].tau_max = tau_max

--- a/tests/test_joint_limits.py
+++ b/tests/test_joint_limits.py
@@ -180,6 +180,27 @@ class TestHillTorqueModel:
         with pytest.raises(ValueError, match="angle_width"):
             HillTorqueModel(tau_max=100, q_optimal=0.0, angle_width=0)
 
+    @pytest.mark.parametrize(
+        ("name", "kwargs"),
+        [
+            ("tau_max", {"tau_max": float("nan")}),
+            ("tau_max", {"tau_max": float("inf")}),
+            ("q_optimal", {"q_optimal": float("nan")}),
+            ("angle_width", {"angle_width": float("inf")}),
+            ("v_max", {"v_max": float("nan")}),
+            ("k_shape", {"k_shape": float("inf")}),
+            ("ecc_factor", {"ecc_factor": float("nan")}),
+            ("max_ecc_ratio", {"max_ecc_ratio": float("inf")}),
+        ],
+    )
+    def test_non_finite_constructor_values_raise(
+        self, name: str, kwargs: dict[str, float]
+    ) -> None:
+        params = {"tau_max": 100.0, "q_optimal": 0.0}
+        params.update(kwargs)
+        with pytest.raises(ValueError, match=name):
+            HillTorqueModel(**params)
+
     def test_batch_angle_factor(self) -> None:
         """Torque-angle factor should vectorize correctly."""
         model = HillTorqueModel(tau_max=200.0, q_optimal=0.5)
@@ -226,6 +247,12 @@ class TestJointTorqueSet:
     def test_set_max_torque(self, default_torque_set: JointTorqueSet) -> None:
         default_torque_set.set_max_torque("knee", 300.0)
         assert default_torque_set.get_max_torque("knee") == 300.0
+
+    def test_set_max_torque_rejects_non_finite(
+        self, default_torque_set: JointTorqueSet
+    ) -> None:
+        with pytest.raises(ValueError, match="tau_max"):
+            default_torque_set.set_max_torque("knee", float("nan"))
 
     def test_set_invalid_joint_raises(self, default_torque_set: JointTorqueSet) -> None:
         with pytest.raises(ValueError, match="Unknown joint"):


### PR DESCRIPTION
## Summary
- Reject NaN/inf HillTorqueModel constructor parameters before they can propagate into torque calculations.
- Reject non-finite updates in JointTorqueSet.set_max_torque.
- Add regression coverage for non-finite constructor and update inputs.

Closes #236

## Validation
- `TMPDIR=/tmp PYTHONPATH=src python3 -m pytest tests/test_joint_limits.py -q`
