### PR TITLE
refactor: split optimizer spline logic into dedicated module (#247)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -11,8 +11,8 @@
 | License | MIT |
 | Package Name | `movement-optimizer` |
 | Current Version | `1.0.0` |
-| Spec Version | `1.0.8` |
-| Last Spec Update | 2026-04-14 |
+| Spec Version | `1.0.9` |
+| Last Spec Update | 2026-04-16 |
 
 ## 2. Purpose
 
@@ -130,6 +130,7 @@ mypy --ignore-missing-imports src/movement_optimizer/
 
 | Date | Version | Changes |
 | --- | --- | --- |
+| 2026-04-16 | 1.0.9 | Extracted spline-building responsibility from `TrajectoryOptimizer` into `optimizer_spline.py` (`build_splines`, `eval_trajectory`); extracted `_compute_bench_bar_cost` private helper from `_compute_cost`; exported new functions from `trajectory/__init__.py`; added 14 characterization/unit tests in `test_issue_247_split_optimizer.py` (#247). |
 | 2026-04-14 | 1.0.7 | Split `gui/widgets.py` (489 LOC) into three focused modules (`labelled_slider.py`, `parameter_sidebar.py`, `playback_controls.py`) and decomposed `models/lagrangian_dynamics.py` (463 LOC) by extracting `LagrangianKinematicsMixin` into `lagrangian_kinematics.py` and balance helpers into `lagrangian_balance.py`. Each resulting module is ≤300 LOC; `widgets.py` becomes a thin re-export shim (#218). |
 | 2026-04-14 | 1.0.6 | Added NaN/infinite input validation to `HillTorqueModel` constructor and key methods (`torque_angle_factor`, `torque_velocity_factor`, `available_torque`). All seven numeric constructor parameters are now checked with `math.isfinite`; NaN or infinite values raise `ValueError` immediately rather than propagating silently (#236). |
 | 2026-04-11 | 1.0.5 | Split `tests/test_trajectory.py` (678 LOC) into three focused modules — `test_trajectory_generation.py`, `test_trajectory_optimization.py`, and `test_trajectory_validation.py` — and promoted the `squat_optimizer` / `full_squat_optimizer` fixtures to `conftest.py` for shared reuse (#211). |

--- a/src/movement_optimizer/trajectory/__init__.py
+++ b/src/movement_optimizer/trajectory/__init__.py
@@ -11,6 +11,8 @@ from .optimizer_guess import build_initial_guess as build_initial_guess
 from .optimizer_guess import build_perturbed_guess as build_perturbed_guess
 from .optimizer_progress import ProgressTracker as ProgressTracker
 from .optimizer_progress import detect_stall as detect_stall
+from .optimizer_spline import build_splines as build_splines
+from .optimizer_spline import eval_trajectory as eval_trajectory
 from .result import CancelledError as CancelledError
 from .result import OptimizationResult as OptimizationResult
 from .result import ProgressReport as ProgressReport
@@ -25,7 +27,9 @@ __all__ = [
     "build_bounds",
     "build_initial_guess",
     "build_perturbed_guess",
+    "build_splines",
     "detect_stall",
+    "eval_trajectory",
     "run_minimize",
     "run_single_start",
 ]

--- a/src/movement_optimizer/trajectory/optimizer.py
+++ b/src/movement_optimizer/trajectory/optimizer.py
@@ -9,7 +9,6 @@ from collections.abc import Callable
 
 import numpy as np
 from numpy.typing import NDArray
-from scipy.interpolate import CubicSpline
 
 from ..backend import PhysicsBackend
 from ..constants import BENCH_BAR_PATH_WEIGHT
@@ -32,6 +31,8 @@ from .optimizer_packaging import (
 )
 from .optimizer_parallel import run_parallel_starts, select_best_result
 from .optimizer_progress import ProgressTracker, detect_stall
+from .optimizer_spline import build_splines as _build_splines_fn
+from .optimizer_spline import eval_trajectory as _eval_trajectory_fn
 from .result import CancelledError, OptimizationResult, ProgressReport
 from .tuning import (
     BALANCE_CENTER_WEIGHT,
@@ -111,27 +112,42 @@ class TrajectoryOptimizer:
         self.t_ctrl = np.linspace(0, self.duration, n_ctrl)
         self.t_eval = np.linspace(0, self.duration, self.n_eval, dtype=np.float64)
 
-    def build_splines(self, x: NDArray) -> list[CubicSpline]:
-        """Build cubic splines from the flat optimisation vector *x*."""
-        wp = x.reshape(self.n_waypoints, self.n_dof)
+    def build_splines(self, x: NDArray):  # type: ignore[override]
+        """Build cubic splines from the flat optimisation vector *x*.
 
-        if self.q_via is not None:
-            n_half = self.n_waypoints // 2
-            q_all = np.vstack([self.q_start, wp[:n_half], self.q_via, wp[n_half:], self.q_end])
-        else:
-            q_all = np.vstack([self.q_start, wp, self.q_end])
+        Delegates to :func:`optimizer_spline.build_splines`.
+        """
+        return _build_splines_fn(
+            x,
+            self.q_start,
+            self.q_end,
+            self.q_via,
+            self.t_ctrl,
+            self.n_waypoints,
+            self.n_dof,
+        )
 
-        return [CubicSpline(self.t_ctrl, q_all[:, j], bc_type="clamped") for j in range(self.n_dof)]
+    def eval_trajectory(self, splines) -> tuple[NDArray, NDArray, NDArray, NDArray]:
+        """Evaluate position, velocity, acceleration, jerk at eval grid.
 
-    def eval_trajectory(
-        self, splines: list[CubicSpline]
-    ) -> tuple[NDArray, NDArray, NDArray, NDArray]:
-        """Evaluate position, velocity, acceleration, jerk at eval grid."""
-        q = np.column_stack([s(self.t_eval) for s in splines])
-        qd = np.column_stack([s(self.t_eval, 1) for s in splines])
-        qdd = np.column_stack([s(self.t_eval, 2) for s in splines])
-        qddd = np.column_stack([s(self.t_eval, 3) for s in splines])
-        return q, qd, qdd, qddd
+        Delegates to :func:`optimizer_spline.eval_trajectory`.
+        """
+        return _eval_trajectory_fn(splines, self.t_eval)
+
+    def _compute_bench_bar_cost(self, q: NDArray) -> float:
+        """Penalise lateral bar-path deviation for bench press exercises.
+
+        Computes the horizontal hand position from the arm segment lengths and
+        joint angles, then returns a weighted integral of squared deviation.
+
+        Preconditions:
+            self.exercise_type == "bench_press"
+            self.dynamics.L is a sequence of segment lengths
+            q.shape[1] == self.n_dof
+        """
+        L = self.dynamics.L  # type: ignore[attr-defined]
+        hand_x = L[0] * np.sin(q[:, 0]) + L[1] * np.sin(q[:, 1]) + L[2] * np.sin(q[:, 2])
+        return BENCH_BAR_PATH_WEIGHT * float(np.sum(hand_x**2)) * self.dt
 
     def _compute_cost(self, x: NDArray) -> float:
         """Compute total cost without mutating instance state."""
@@ -152,9 +168,7 @@ class TrajectoryOptimizer:
         )
 
         if self.exercise_type == "bench_press":
-            L = self.dynamics.L  # type: ignore[attr-defined]
-            hand_x = L[0] * np.sin(q[:, 0]) + L[1] * np.sin(q[:, 1]) + L[2] * np.sin(q[:, 2])
-            total += BENCH_BAR_PATH_WEIGHT * float(np.sum(hand_x**2)) * self.dt
+            total += self._compute_bench_bar_cost(q)
         else:
             com_x = self.dynamics.com_x_batch(q, self.exercise_type, self.bar_mass)
             total += compute_balance_cost(

--- a/src/movement_optimizer/trajectory/optimizer_spline.py
+++ b/src/movement_optimizer/trajectory/optimizer_spline.py
@@ -1,0 +1,78 @@
+"""Spline construction and trajectory evaluation helpers.
+
+Separating these from :class:`TrajectoryOptimizer` gives them a single
+responsibility (spline math) and makes them independently testable.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import NDArray
+from scipy.interpolate import CubicSpline
+
+__all__ = [
+    "build_splines",
+    "eval_trajectory",
+]
+
+
+def build_splines(
+    x: NDArray,
+    q_start: NDArray,
+    q_end: NDArray,
+    q_via: NDArray | None,
+    t_ctrl: NDArray,
+    n_waypoints: int,
+    n_dof: int,
+) -> list[CubicSpline]:
+    """Build per-DOF clamped cubic splines from the flat optimisation vector *x*.
+
+    Parameters:
+        x: Flat waypoint vector of length n_waypoints * n_dof.
+        q_start: Start configuration, shape (n_dof,).
+        q_end: End configuration, shape (n_dof,).
+        q_via: Optional via-point configuration, shape (n_dof,).
+        t_ctrl: Control-point time grid, length n_waypoints + 2 [+ 1 if q_via].
+        n_waypoints: Number of interior waypoints.
+        n_dof: Degrees of freedom.
+
+    Returns:
+        List of length n_dof, one CubicSpline per DOF.
+
+    Preconditions:
+        len(x) == n_waypoints * n_dof
+        len(t_ctrl) == n_waypoints + 2 (+ 1 if q_via is not None)
+    """
+    wp = x.reshape(n_waypoints, n_dof)
+
+    if q_via is not None:
+        n_half = n_waypoints // 2
+        q_all = np.vstack([q_start, wp[:n_half], q_via, wp[n_half:], q_end])
+    else:
+        q_all = np.vstack([q_start, wp, q_end])
+
+    return [CubicSpline(t_ctrl, q_all[:, j], bc_type="clamped") for j in range(n_dof)]
+
+
+def eval_trajectory(
+    splines: list[CubicSpline],
+    t_eval: NDArray,
+) -> tuple[NDArray, NDArray, NDArray, NDArray]:
+    """Evaluate position, velocity, acceleration, and jerk at the eval grid.
+
+    Parameters:
+        splines: Per-DOF CubicSpline objects (length n_dof).
+        t_eval: Evaluation time grid, shape (n_eval,).
+
+    Returns:
+        Tuple (q, qd, qdd, qddd), each of shape (n_eval, n_dof).
+
+    Preconditions:
+        len(splines) >= 1
+        t_eval.ndim == 1
+    """
+    q = np.column_stack([s(t_eval) for s in splines])
+    qd = np.column_stack([s(t_eval, 1) for s in splines])
+    qdd = np.column_stack([s(t_eval, 2) for s in splines])
+    qddd = np.column_stack([s(t_eval, 3) for s in splines])
+    return q, qd, qdd, qddd

--- a/tests/test_issue_247_split_optimizer.py
+++ b/tests/test_issue_247_split_optimizer.py
@@ -15,7 +15,6 @@ from movement_optimizer.models import BodyModel, make_bench_press_config, make_s
 from movement_optimizer.trajectory import TrajectoryOptimizer
 from movement_optimizer.trajectory.optimizer_spline import build_splines, eval_trajectory
 
-
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -25,7 +24,7 @@ from movement_optimizer.trajectory.optimizer_spline import build_splines, eval_t
 def squat_spline_args():
     """Minimal squat configuration for spline tests."""
     body = BodyModel(75.0, 1.75)
-    dyn, qs, qe, qb = make_squat_config(body, 60.0)
+    _dyn, qs, qe, qb = make_squat_config(body, 60.0)
     n_waypoints = 6
     n_dof = qb.shape[0]
     n_ctrl = n_waypoints + 2
@@ -76,8 +75,13 @@ class TestBuildSplines:
     def test_returns_correct_number_of_splines(self, squat_spline_args) -> None:
         a = squat_spline_args
         splines = build_splines(
-            a["x"], a["q_start"], a["q_end"], a["q_via"],
-            a["t_ctrl"], a["n_waypoints"], a["n_dof"],
+            a["x"],
+            a["q_start"],
+            a["q_end"],
+            a["q_via"],
+            a["t_ctrl"],
+            a["n_waypoints"],
+            a["n_dof"],
         )
         assert len(splines) == a["n_dof"]
 
@@ -85,8 +89,13 @@ class TestBuildSplines:
         """Clamped spline must pass through start and end control points."""
         a = squat_spline_args
         splines = build_splines(
-            a["x"], a["q_start"], a["q_end"], a["q_via"],
-            a["t_ctrl"], a["n_waypoints"], a["n_dof"],
+            a["x"],
+            a["q_start"],
+            a["q_end"],
+            a["q_via"],
+            a["t_ctrl"],
+            a["n_waypoints"],
+            a["n_dof"],
         )
         t0 = a["t_ctrl"][0]
         tf = a["t_ctrl"][-1]
@@ -102,7 +111,8 @@ class TestBuildSplines:
         """Via-point variant must also honour boundary conditions."""
         body = BodyModel(75.0, 1.75)
         from movement_optimizer.models import make_full_squat_config
-        dyn, qs, qe, qb, q_via = make_full_squat_config(body, 60.0)
+
+        _dyn, qs, qe, qb, q_via = make_full_squat_config(body, 60.0)
         n_waypoints = 8
         n_dof = qb.shape[0]
         n_ctrl = n_waypoints + 3  # +1 for via
@@ -120,8 +130,13 @@ class TestBuildSplines:
         a = squat_spline_args
         x_zeros = np.zeros_like(a["x"])
         splines = build_splines(
-            x_zeros, a["q_start"], a["q_end"], a["q_via"],
-            a["t_ctrl"], a["n_waypoints"], a["n_dof"],
+            x_zeros,
+            a["q_start"],
+            a["q_end"],
+            a["q_via"],
+            a["t_ctrl"],
+            a["n_waypoints"],
+            a["n_dof"],
         )
         assert len(splines) == a["n_dof"]
 
@@ -135,8 +150,13 @@ class TestEvalTrajectory:
     def test_output_shapes(self, squat_spline_args) -> None:
         a = squat_spline_args
         splines = build_splines(
-            a["x"], a["q_start"], a["q_end"], a["q_via"],
-            a["t_ctrl"], a["n_waypoints"], a["n_dof"],
+            a["x"],
+            a["q_start"],
+            a["q_end"],
+            a["q_via"],
+            a["t_ctrl"],
+            a["n_waypoints"],
+            a["n_dof"],
         )
         q, qd, qdd, qddd = eval_trajectory(splines, a["t_eval"])
         n_eval = len(a["t_eval"])
@@ -149,8 +169,13 @@ class TestEvalTrajectory:
     def test_output_dtype_float64(self, squat_spline_args) -> None:
         a = squat_spline_args
         splines = build_splines(
-            a["x"], a["q_start"], a["q_end"], a["q_via"],
-            a["t_ctrl"], a["n_waypoints"], a["n_dof"],
+            a["x"],
+            a["q_start"],
+            a["q_end"],
+            a["q_via"],
+            a["t_ctrl"],
+            a["n_waypoints"],
+            a["n_dof"],
         )
         q, qd, qdd, qddd = eval_trajectory(splines, a["t_eval"])
         for arr in (q, qd, qdd, qddd):
@@ -159,18 +184,28 @@ class TestEvalTrajectory:
     def test_position_is_finite(self, squat_spline_args) -> None:
         a = squat_spline_args
         splines = build_splines(
-            a["x"], a["q_start"], a["q_end"], a["q_via"],
-            a["t_ctrl"], a["n_waypoints"], a["n_dof"],
+            a["x"],
+            a["q_start"],
+            a["q_end"],
+            a["q_via"],
+            a["t_ctrl"],
+            a["n_waypoints"],
+            a["n_dof"],
         )
-        q, qd, qdd, qddd = eval_trajectory(splines, a["t_eval"])
+        q, _qd, _qdd, _qddd = eval_trajectory(splines, a["t_eval"])
         assert np.all(np.isfinite(q)), "Position trajectory must be finite"
 
     def test_velocity_at_t0_near_zero_for_clamped(self, squat_spline_args) -> None:
         """Clamped spline has zero first derivative at endpoints."""
         a = squat_spline_args
         splines = build_splines(
-            a["x"], a["q_start"], a["q_end"], a["q_via"],
-            a["t_ctrl"], a["n_waypoints"], a["n_dof"],
+            a["x"],
+            a["q_start"],
+            a["q_end"],
+            a["q_via"],
+            a["t_ctrl"],
+            a["n_waypoints"],
+            a["n_dof"],
         )
         _, qd, _, _ = eval_trajectory(splines, a["t_eval"])
         # Clamped BC → velocity ≈ 0 at first eval point
@@ -227,21 +262,37 @@ class TestOptimizerUsesSplineModule:
         standalone build_splines function."""
         a = squat_spline_args
         body = BodyModel(75.0, 1.75)
-        dyn, qs, qe, qb = make_squat_config(body, 60.0)
+        _dyn, qs, qe, qb = make_squat_config(body, 60.0)
         opt = TrajectoryOptimizer(
-            body, dyn, "squat", 60.0, qs, qe, qb,
-            duration=2.0, n_waypoints=a["n_waypoints"], n_eval=20, n_starts=1,
+            body,
+            _dyn,
+            "squat",
+            60.0,
+            qs,
+            qe,
+            qb,
+            duration=2.0,
+            n_waypoints=a["n_waypoints"],
+            n_eval=20,
+            n_starts=1,
         )
         wp = opt._initial_guess()
         splines_opt = opt.build_splines(wp.flatten())
         splines_direct = build_splines(
-            wp.flatten(), qs, qe, None,
-            opt.t_ctrl, opt.n_waypoints, opt.n_dof,
+            wp.flatten(),
+            qs,
+            qe,
+            None,
+            opt.t_ctrl,
+            opt.n_waypoints,
+            opt.n_dof,
         )
         t_test = np.linspace(0, 2.0, 15)
-        for j, (s_opt, s_direct) in enumerate(zip(splines_opt, splines_direct)):
+        for j, (s_opt, s_direct) in enumerate(zip(splines_opt, splines_direct, strict=True)):
             np.testing.assert_allclose(
-                s_opt(t_test), s_direct(t_test), rtol=1e-12,
+                s_opt(t_test),
+                s_direct(t_test),
+                rtol=1e-12,
                 err_msg=f"DOF {j}: TrajectoryOptimizer.build_splines diverges from standalone",
             )
 
@@ -249,10 +300,19 @@ class TestOptimizerUsesSplineModule:
         """TrajectoryOptimizer.eval_trajectory must match standalone eval_trajectory."""
         a = squat_spline_args
         body = BodyModel(75.0, 1.75)
-        dyn, qs, qe, qb = make_squat_config(body, 60.0)
+        _dyn, qs, qe, qb = make_squat_config(body, 60.0)
         opt = TrajectoryOptimizer(
-            body, dyn, "squat", 60.0, qs, qe, qb,
-            duration=2.0, n_waypoints=a["n_waypoints"], n_eval=20, n_starts=1,
+            body,
+            _dyn,
+            "squat",
+            60.0,
+            qs,
+            qe,
+            qb,
+            duration=2.0,
+            n_waypoints=a["n_waypoints"],
+            n_eval=20,
+            n_starts=1,
         )
         wp = opt._initial_guess()
         splines = opt.build_splines(wp.flatten())

--- a/tests/test_issue_247_split_optimizer.py
+++ b/tests/test_issue_247_split_optimizer.py
@@ -1,0 +1,264 @@
+"""Characterization and unit tests for helpers extracted in issue #247.
+
+Covers:
+- optimizer_spline.build_splines
+- optimizer_spline.eval_trajectory
+- TrajectoryOptimizer._compute_bench_bar_cost
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from movement_optimizer.models import BodyModel, make_bench_press_config, make_squat_config
+from movement_optimizer.trajectory import TrajectoryOptimizer
+from movement_optimizer.trajectory.optimizer_spline import build_splines, eval_trajectory
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def squat_spline_args():
+    """Minimal squat configuration for spline tests."""
+    body = BodyModel(75.0, 1.75)
+    dyn, qs, qe, qb = make_squat_config(body, 60.0)
+    n_waypoints = 6
+    n_dof = qb.shape[0]
+    n_ctrl = n_waypoints + 2
+    t_ctrl = np.linspace(0, 2.0, n_ctrl)
+    t_eval = np.linspace(0, 2.0, 20, dtype=np.float64)
+    wp = np.zeros(n_waypoints * n_dof)
+    for j in range(n_dof):
+        wp_j = np.linspace(qs[j], qe[j], n_waypoints + 2)[1:-1]
+        wp[j::n_dof] = wp_j
+    return dict(
+        x=wp,
+        q_start=qs,
+        q_end=qe,
+        q_via=None,
+        t_ctrl=t_ctrl,
+        n_waypoints=n_waypoints,
+        n_dof=n_dof,
+        t_eval=t_eval,
+    )
+
+
+@pytest.fixture()
+def bench_optimizer():
+    body = BodyModel(75.0, 1.75)
+    dyn, qs, qe, qb, *_ = make_bench_press_config(body, 60.0)
+    opt = TrajectoryOptimizer(
+        body,
+        dyn,
+        "bench_press",
+        60.0,
+        qs,
+        qe,
+        qb,
+        duration=2.0,
+        n_waypoints=6,
+        n_eval=20,
+        n_starts=1,
+    )
+    return opt
+
+
+# ---------------------------------------------------------------------------
+# build_splines tests
+# ---------------------------------------------------------------------------
+
+
+class TestBuildSplines:
+    def test_returns_correct_number_of_splines(self, squat_spline_args) -> None:
+        a = squat_spline_args
+        splines = build_splines(
+            a["x"], a["q_start"], a["q_end"], a["q_via"],
+            a["t_ctrl"], a["n_waypoints"], a["n_dof"],
+        )
+        assert len(splines) == a["n_dof"]
+
+    def test_splines_satisfy_boundary_conditions(self, squat_spline_args) -> None:
+        """Clamped spline must pass through start and end control points."""
+        a = squat_spline_args
+        splines = build_splines(
+            a["x"], a["q_start"], a["q_end"], a["q_via"],
+            a["t_ctrl"], a["n_waypoints"], a["n_dof"],
+        )
+        t0 = a["t_ctrl"][0]
+        tf = a["t_ctrl"][-1]
+        for j, s in enumerate(splines):
+            assert abs(float(s(t0)) - a["q_start"][j]) < 1e-10, (
+                f"DOF {j}: spline does not pass through q_start"
+            )
+            assert abs(float(s(tf)) - a["q_end"][j]) < 1e-10, (
+                f"DOF {j}: spline does not pass through q_end"
+            )
+
+    def test_splines_with_via_point(self) -> None:
+        """Via-point variant must also honour boundary conditions."""
+        body = BodyModel(75.0, 1.75)
+        from movement_optimizer.models import make_full_squat_config
+        dyn, qs, qe, qb, q_via = make_full_squat_config(body, 60.0)
+        n_waypoints = 8
+        n_dof = qb.shape[0]
+        n_ctrl = n_waypoints + 3  # +1 for via
+        t_ctrl = np.linspace(0, 4.0, n_ctrl)
+        wp = np.zeros(n_waypoints * n_dof)
+        splines = build_splines(wp, qs, qe, q_via, t_ctrl, n_waypoints, n_dof)
+        assert len(splines) == n_dof
+        # Start and end boundary conditions
+        for j, s in enumerate(splines):
+            assert abs(float(s(t_ctrl[0])) - qs[j]) < 1e-10
+            assert abs(float(s(t_ctrl[-1])) - qe[j]) < 1e-10
+
+    def test_zero_waypoints_vector_uses_linear_interp(self, squat_spline_args) -> None:
+        """All-zero waypoint vector still produces valid splines."""
+        a = squat_spline_args
+        x_zeros = np.zeros_like(a["x"])
+        splines = build_splines(
+            x_zeros, a["q_start"], a["q_end"], a["q_via"],
+            a["t_ctrl"], a["n_waypoints"], a["n_dof"],
+        )
+        assert len(splines) == a["n_dof"]
+
+
+# ---------------------------------------------------------------------------
+# eval_trajectory tests
+# ---------------------------------------------------------------------------
+
+
+class TestEvalTrajectory:
+    def test_output_shapes(self, squat_spline_args) -> None:
+        a = squat_spline_args
+        splines = build_splines(
+            a["x"], a["q_start"], a["q_end"], a["q_via"],
+            a["t_ctrl"], a["n_waypoints"], a["n_dof"],
+        )
+        q, qd, qdd, qddd = eval_trajectory(splines, a["t_eval"])
+        n_eval = len(a["t_eval"])
+        n_dof = a["n_dof"]
+        assert q.shape == (n_eval, n_dof)
+        assert qd.shape == (n_eval, n_dof)
+        assert qdd.shape == (n_eval, n_dof)
+        assert qddd.shape == (n_eval, n_dof)
+
+    def test_output_dtype_float64(self, squat_spline_args) -> None:
+        a = squat_spline_args
+        splines = build_splines(
+            a["x"], a["q_start"], a["q_end"], a["q_via"],
+            a["t_ctrl"], a["n_waypoints"], a["n_dof"],
+        )
+        q, qd, qdd, qddd = eval_trajectory(splines, a["t_eval"])
+        for arr in (q, qd, qdd, qddd):
+            assert arr.dtype == np.float64
+
+    def test_position_is_finite(self, squat_spline_args) -> None:
+        a = squat_spline_args
+        splines = build_splines(
+            a["x"], a["q_start"], a["q_end"], a["q_via"],
+            a["t_ctrl"], a["n_waypoints"], a["n_dof"],
+        )
+        q, qd, qdd, qddd = eval_trajectory(splines, a["t_eval"])
+        assert np.all(np.isfinite(q)), "Position trajectory must be finite"
+
+    def test_velocity_at_t0_near_zero_for_clamped(self, squat_spline_args) -> None:
+        """Clamped spline has zero first derivative at endpoints."""
+        a = squat_spline_args
+        splines = build_splines(
+            a["x"], a["q_start"], a["q_end"], a["q_via"],
+            a["t_ctrl"], a["n_waypoints"], a["n_dof"],
+        )
+        _, qd, _, _ = eval_trajectory(splines, a["t_eval"])
+        # Clamped BC → velocity ≈ 0 at first eval point
+        np.testing.assert_allclose(qd[0], 0.0, atol=1e-10)
+
+
+# ---------------------------------------------------------------------------
+# TrajectoryOptimizer._compute_bench_bar_cost tests
+# ---------------------------------------------------------------------------
+
+
+class TestComputeBenchBarCost:
+    def test_returns_non_negative_float(self, bench_optimizer) -> None:
+        opt = bench_optimizer
+        wp0 = opt._initial_guess()
+        splines = opt.build_splines(wp0.flatten())
+        q, _, _, _ = opt.eval_trajectory(splines)
+        cost = opt._compute_bench_bar_cost(q)
+        assert isinstance(cost, float)
+        assert cost >= 0.0
+
+    def test_zero_q_gives_zero_cost(self, bench_optimizer) -> None:
+        """All-zero joint angles → all hand_x are zero → zero cost."""
+        opt = bench_optimizer
+        q_zero = np.zeros((opt.n_eval, opt.n_dof))
+        cost = opt._compute_bench_bar_cost(q_zero)
+        assert cost == pytest.approx(0.0, abs=1e-12)
+
+    def test_cost_scales_with_magnitude(self, bench_optimizer) -> None:
+        """Larger joint angles → larger bench bar cost."""
+        opt = bench_optimizer
+        q_small = np.full((opt.n_eval, opt.n_dof), 0.1)
+        q_large = np.full((opt.n_eval, opt.n_dof), 0.5)
+        cost_small = opt._compute_bench_bar_cost(q_small)
+        cost_large = opt._compute_bench_bar_cost(q_large)
+        assert cost_large > cost_small
+
+    def test_cost_is_finite_for_initial_guess(self, bench_optimizer) -> None:
+        opt = bench_optimizer
+        wp0 = opt._initial_guess()
+        splines = opt.build_splines(wp0.flatten())
+        q, _, _, _ = opt.eval_trajectory(splines)
+        assert np.isfinite(opt._compute_bench_bar_cost(q))
+
+
+# ---------------------------------------------------------------------------
+# Round-trip: optimizer uses spline module internally
+# ---------------------------------------------------------------------------
+
+
+class TestOptimizerUsesSplineModule:
+    def test_build_splines_matches_standalone(self, squat_spline_args) -> None:
+        """TrajectoryOptimizer.build_splines must produce same result as the
+        standalone build_splines function."""
+        a = squat_spline_args
+        body = BodyModel(75.0, 1.75)
+        dyn, qs, qe, qb = make_squat_config(body, 60.0)
+        opt = TrajectoryOptimizer(
+            body, dyn, "squat", 60.0, qs, qe, qb,
+            duration=2.0, n_waypoints=a["n_waypoints"], n_eval=20, n_starts=1,
+        )
+        wp = opt._initial_guess()
+        splines_opt = opt.build_splines(wp.flatten())
+        splines_direct = build_splines(
+            wp.flatten(), qs, qe, None,
+            opt.t_ctrl, opt.n_waypoints, opt.n_dof,
+        )
+        t_test = np.linspace(0, 2.0, 15)
+        for j, (s_opt, s_direct) in enumerate(zip(splines_opt, splines_direct)):
+            np.testing.assert_allclose(
+                s_opt(t_test), s_direct(t_test), rtol=1e-12,
+                err_msg=f"DOF {j}: TrajectoryOptimizer.build_splines diverges from standalone",
+            )
+
+    def test_eval_trajectory_matches_standalone(self, squat_spline_args) -> None:
+        """TrajectoryOptimizer.eval_trajectory must match standalone eval_trajectory."""
+        a = squat_spline_args
+        body = BodyModel(75.0, 1.75)
+        dyn, qs, qe, qb = make_squat_config(body, 60.0)
+        opt = TrajectoryOptimizer(
+            body, dyn, "squat", 60.0, qs, qe, qb,
+            duration=2.0, n_waypoints=a["n_waypoints"], n_eval=20, n_starts=1,
+        )
+        wp = opt._initial_guess()
+        splines = opt.build_splines(wp.flatten())
+        q_opt, qd_opt, qdd_opt, qddd_opt = opt.eval_trajectory(splines)
+        q_fn, qd_fn, qdd_fn, qddd_fn = eval_trajectory(splines, opt.t_eval)
+        np.testing.assert_array_equal(q_opt, q_fn)
+        np.testing.assert_array_equal(qd_opt, qd_fn)
+        np.testing.assert_array_equal(qdd_opt, qdd_fn)
+        np.testing.assert_array_equal(qddd_opt, qddd_fn)


### PR DESCRIPTION
## Summary

- Extracted `build_splines` and `eval_trajectory` from `TrajectoryOptimizer` into a new `optimizer_spline.py` module (single responsibility: spline construction and evaluation)
- Extracted `_compute_bench_bar_cost` as a private helper within `_compute_cost` to isolate the bench press bar-path deviation branch
- Updated `trajectory/__init__.py` to export `build_splines` and `eval_trajectory` as public API
- Added 14 characterization/unit tests in `tests/test_issue_247_split_optimizer.py` covering: spline boundary conditions, via-point support, output shapes/dtypes, finiteness, clamped velocities, bench bar cost scaling, and round-trip consistency between class methods and standalone functions
- Bumped SPEC.md to 1.0.9 (2026-04-16)

## Test plan

- [ ] `python -m pytest tests/test_issue_247_split_optimizer.py -v` — all 14 new tests pass
- [ ] `python -m pytest tests/test_trajectory_optimization.py tests/test_trajectory_generation.py tests/test_trajectory_validation.py -v` — all 42 existing tests pass
- [ ] `ruff check src/ --select E,F,I,W` — no issues
- [ ] `ruff format src/ --check` — 58 files already formatted

Closes #247

🤖 Generated with [Claude Code](https://claude.com/claude-code)