### PR TITLE
Type annotate trajectory optimizer wrappers

### DIFF
--- a/src/movement_optimizer/trajectory/optimizer.py
+++ b/src/movement_optimizer/trajectory/optimizer.py
@@ -113,7 +113,7 @@ class TrajectoryOptimizer:
         self.t_ctrl = np.linspace(0, self.duration, n_ctrl)
         self.t_eval = np.linspace(0, self.duration, self.n_eval, dtype=np.float64)
 
-    def build_splines(self, x: NDArray):  # type: ignore[override]
+    def build_splines(self, x: NDArray) -> list[CubicSpline]:
         """Build cubic splines from the flat optimisation vector *x*.
 
         Delegates to :func:`optimizer_spline.build_splines`.

--- a/src/movement_optimizer/trajectory/optimizer.py
+++ b/src/movement_optimizer/trajectory/optimizer.py
@@ -9,6 +9,7 @@ from collections.abc import Callable
 
 import numpy as np
 from numpy.typing import NDArray
+from scipy.interpolate import CubicSpline
 
 from ..backend import PhysicsBackend
 from ..constants import BENCH_BAR_PATH_WEIGHT
@@ -127,7 +128,9 @@ class TrajectoryOptimizer:
             self.n_dof,
         )
 
-    def eval_trajectory(self, splines) -> tuple[NDArray, NDArray, NDArray, NDArray]:
+    def eval_trajectory(
+        self, splines: list[CubicSpline]
+    ) -> tuple[NDArray, NDArray, NDArray, NDArray]:
         """Evaluate position, velocity, acceleration, jerk at eval grid.
 
         Delegates to :func:`optimizer_spline.eval_trajectory`.


### PR DESCRIPTION
Closes #253
Closes #254

## Summary
- Restore the build_splines return annotation
- Type the eval_trajectory splines input

## Validation
- python -m pytest tests/test_issue_247_split_optimizer.py tests/test_trajectory_generation.py
- python -m ruff check src/movement_optimizer/trajectory/optimizer.py
- python -m mypy src/movement_optimizer/trajectory/optimizer.py