### PR TITLE
🎨 Palette: Improve accessibility of playback control buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2024-05-18 - Added ARIA labels and tooltips to icon-only playback buttons
+**Learning:** PyQt6 `QPushButton` widgets using only Unicode icons (like `\u23ee` for rewind) are inaccessible to screen readers without an explicit `accessibleName`. Tooltips (`setToolTip`) also greatly enhance mouse/visual usability, particularly since users might not recognize all unicode symbol conventions intuitively.
+**Action:** Always set `setAccessibleName()` and `setToolTip()` on icon-only PyQt6 buttons, and ensure dynamically updated buttons (like Play/Pause toggles) update their tooltips and accessible names alongside their text/icons.

--- a/src/movement_optimizer/gui/playback_controls.py
+++ b/src/movement_optimizer/gui/playback_controls.py
@@ -19,10 +19,21 @@ class PlaybackControls(QWidget):
         layout.setContentsMargins(4, 4, 4, 4)
 
         self.btn_rewind = QPushButton("\u23ee")
+        self.btn_rewind.setToolTip("Rewind to start")
+        self.btn_rewind.setAccessibleName("Rewind to start")
+
         self.btn_back = QPushButton("\u25c0")
+        self.btn_back.setToolTip("Step backward one frame")
+        self.btn_back.setAccessibleName("Step backward")
+
         self.btn_play = QPushButton("\u25b6 Play")
         self.btn_play.setProperty("class", "primary")
+        self.btn_play.setToolTip("Play animation")
+        self.btn_play.setAccessibleName("Play animation")
+
         self.btn_fwd = QPushButton("\u25b6")
+        self.btn_fwd.setToolTip("Step forward one frame")
+        self.btn_fwd.setAccessibleName("Step forward")
 
         self.btn_rewind.clicked.connect(self.rewind.emit)
         self.btn_back.clicked.connect(self.step_back.emit)
@@ -51,4 +62,11 @@ class PlaybackControls(QWidget):
         layout.addWidget(self.frame_label)
 
     def set_playing(self, playing: bool) -> None:
-        self.btn_play.setText("\u23f8 Pause" if playing else "\u25b6 Play")
+        if playing:
+            self.btn_play.setText("\u23f8 Pause")
+            self.btn_play.setToolTip("Pause animation")
+            self.btn_play.setAccessibleName("Pause animation")
+        else:
+            self.btn_play.setText("\u25b6 Play")
+            self.btn_play.setToolTip("Play animation")
+            self.btn_play.setAccessibleName("Play animation")


### PR DESCRIPTION
💡 What: Added explicitly set `setToolTip` and `setAccessibleName` values to the `btn_rewind`, `btn_back`, `btn_play`, and `btn_fwd` buttons in `playback_controls.py`. Added logic in `set_playing` to dynamically toggle these values for the play/pause state.
🎯 Why: The transport bar previously relied solely on Unicode characters for its visual iconography (e.g. `\u23ee` for rewind), which are unintuitive for screen readers and can sometimes be confusing for typical users without hover contexts. This guarantees clearer accessibility for disabled users and improves quality of life with mouse hover.
♿ Accessibility: Explicit `setAccessibleName` ensures screen readers announce the button purpose correctly, rather than attempting to read Unicode characters out loud.

---
*PR created automatically by Jules for task [15879729990960057734](https://jules.google.com/task/15879729990960057734) started by @dieterolson*