### PR TITLE
🎨 Palette: Add accessibility names and tooltips to playback controls

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-04-21 - PyQt6 Accessibility
+**Learning:** PyQt6 accessibility (screen reader names) and UX tooltips can be added easily with `setAccessibleName()` and `setToolTip()`, and dynamically updating them is required for toggle buttons (like play/pause).
+**Action:** Always check icon-only PyQt6 buttons and sliders for missing tooltips and accessible names.

--- a/src/movement_optimizer/gui/playback_controls.py
+++ b/src/movement_optimizer/gui/playback_controls.py
@@ -19,10 +19,18 @@ class PlaybackControls(QWidget):
         layout.setContentsMargins(4, 4, 4, 4)
 
         self.btn_rewind = QPushButton("\u23ee")
+        self.btn_rewind.setToolTip("Rewind to start")
+        self.btn_rewind.setAccessibleName("Rewind to start")
         self.btn_back = QPushButton("\u25c0")
+        self.btn_back.setToolTip("Step backward")
+        self.btn_back.setAccessibleName("Step backward")
         self.btn_play = QPushButton("\u25b6 Play")
+        self.btn_play.setToolTip("Play animation")
+        self.btn_play.setAccessibleName("Play animation")
         self.btn_play.setProperty("class", "primary")
         self.btn_fwd = QPushButton("\u25b6")
+        self.btn_fwd.setToolTip("Step forward")
+        self.btn_fwd.setAccessibleName("Step forward")
 
         self.btn_rewind.clicked.connect(self.rewind.emit)
         self.btn_back.clicked.connect(self.step_back.emit)
@@ -39,6 +47,7 @@ class PlaybackControls(QWidget):
         self.speed_slider.setRange(1, 30)
         self.speed_slider.setValue(10)
         self.speed_slider.setFixedWidth(100)
+        self.speed_slider.setAccessibleName("Playback speed")
         self.speed_slider.valueChanged.connect(lambda v: self.speed_changed.emit(v / 10.0))
         layout.addWidget(self.speed_slider)
 
@@ -52,3 +61,5 @@ class PlaybackControls(QWidget):
 
     def set_playing(self, playing: bool) -> None:
         self.btn_play.setText("\u23f8 Pause" if playing else "\u25b6 Play")
+        self.btn_play.setToolTip("Pause animation" if playing else "Play animation")
+        self.btn_play.setAccessibleName("Pause animation" if playing else "Play animation")


### PR DESCRIPTION
💡 **What:** Added `setToolTip` and `setAccessibleName` to the icon-only transport buttons (Rewind, Step Backward, Play, Step Forward) and the Playback Speed slider in `playback_controls.py`. Updated the Play button's tooltip and accessible name dynamically when toggling between Play and Pause states.

🎯 **Why:** Icon-only buttons without tooltips make it harder for users to understand what each button does. Additionally, without accessible names, screen readers cannot announce these interactive elements correctly to users with visual impairments. This small fix significantly improves both usability and accessibility for the animation controls.

♿ **Accessibility:**
- Screen readers will now read "Rewind to start", "Step backward", "Play animation", "Step forward", and "Playback speed".
- The Play/Pause button updates its accessible name dynamically based on its state.
- Tooltips provide visual hints for sighted users.

---
*PR created automatically by Jules for task [667595911600545159](https://jules.google.com/task/667595911600545159) started by @dieterolson*