### PR TITLE
fix: reduce deep traversal and split lagrangian_dynamics module

### DIFF
--- a/src/movement_optimizer/gui/file_operations.py
+++ b/src/movement_optimizer/gui/file_operations.py
@@ -60,17 +60,9 @@ class FileOperationsMixin:
         if not path:
             return
         try:
-            body_params = {
-                "body_mass": self.sidebar.mass_slider.value(),
-                "height": self.sidebar.height_slider.value(),
-                "seg_multipliers": {
-                    "lower_leg": self.sidebar.ll_slider.value(),
-                    "upper_leg": self.sidebar.ul_slider.value(),
-                    "torso": self.sidebar.to_slider.value(),
-                },
-            }
+            body_params = self.sidebar.get_body_params_dict()
             _, etype = self.EXERCISE_CONFIGS[idx]
-            bar = self.sidebar.bar_slider.value()
+            bar, _dur, _smooth = self.sidebar.get_optimization_params()
             save_solution(path, r, body_params, etype, bar)
             self.status_label.setText(f"Saved: {os.path.basename(path)}")
         except (OSError, TypeError, ValueError) as e:

--- a/src/movement_optimizer/gui/optimization_mixin.py
+++ b/src/movement_optimizer/gui/optimization_mixin.py
@@ -45,9 +45,7 @@ class OptimizationMixin:
 
     def _resolve_exercise_params(self, idx: int) -> tuple[Any, Any, str, float, float, float]:
         body = self.sidebar.get_body_model()  # type: ignore[attr-defined]
-        bar = self.sidebar.bar_slider.value()  # type: ignore[attr-defined]
-        dur = self.sidebar.dur_slider.value()  # type: ignore[attr-defined]
-        smoothness = self.sidebar.smooth_slider.value()  # type: ignore[attr-defined]
+        bar, dur, smoothness = self.sidebar.get_optimization_params()  # type: ignore[attr-defined]
         _, etype = self.EXERCISE_CONFIGS[idx]
 
         factory = EXERCISE_FACTORIES[etype]
@@ -74,11 +72,7 @@ class OptimizationMixin:
         return body, dyn, etype, bar, dur, smoothness
 
     def _seg_mults(self) -> dict[str, float]:
-        return {
-            "lower_leg": self.sidebar.ll_slider.value(),  # type: ignore[attr-defined]
-            "upper_leg": self.sidebar.ul_slider.value(),  # type: ignore[attr-defined]
-            "torso": self.sidebar.to_slider.value(),  # type: ignore[attr-defined]
-        }
+        return self.sidebar.get_segment_multipliers()  # type: ignore[attr-defined]
 
     def _run_optimizer(
         self,
@@ -185,7 +179,6 @@ class OptimizationMixin:
     ) -> None:
         """Handle successful optimization completion (called from main thread via signal)."""
         try:
-            self.sidebar.progress.setValue(100)  # type: ignore[attr-defined]
             name = self.EXERCISE_CONFIGS[idx][0]  # type: ignore[attr-defined]
             _, etype = self.EXERCISE_CONFIGS[idx]  # type: ignore[attr-defined]
             self._update_result_summary(name, result, exercise_type=etype)
@@ -196,17 +189,16 @@ class OptimizationMixin:
             t_str = (
                 f"{elapsed:.1f}s" if elapsed < 60 else f"{int(elapsed // 60)}m {elapsed % 60:.0f}s"
             )
-            self.sidebar.prog_label.setText(f"Done in {t_str} ({result.n_evals} evals)")  # type: ignore[attr-defined]
+            self.sidebar.set_progress_done(t_str, result.n_evals)  # type: ignore[attr-defined]
             self._enable_post_run_buttons()
             if result.success:
-                self.sidebar.stall_label.setVisible(False)  # type: ignore[attr-defined]
+                self.sidebar.clear_stall_message()  # type: ignore[attr-defined]
                 status_msg = f"{name} optimization complete in {t_str}!"
             else:
-                self.sidebar.stall_label.setText(  # type: ignore[attr-defined]
+                self.sidebar.set_stall_message(  # type: ignore[attr-defined]
                     "\u26a0 COM went outside the inner 60% BOS zone. "
                     "Try increasing smoothness or adjusting body parameters."
                 )
-                self.sidebar.stall_label.setVisible(True)  # type: ignore[attr-defined]
                 status_msg = f"{name} done in {t_str} -- WARNING: COM balance violated"
             self._finish_or_chain(then_chain, status_msg)
         except (ValueError, RuntimeError, OSError, AttributeError) as exc:
@@ -219,11 +211,7 @@ class OptimizationMixin:
 
     def _enable_post_run_buttons(self) -> None:
         """Enable export/save/compare buttons after a successful optimization run."""
-        self.sidebar.export_btn.setEnabled(True)  # type: ignore[attr-defined]
-        self.sidebar.save_btn.setEnabled(True)  # type: ignore[attr-defined]
-        self.sidebar.export_video_btn.setEnabled(True)  # type: ignore[attr-defined]
-        self.sidebar.export_plots_btn.setEnabled(True)  # type: ignore[attr-defined]
-        self.sidebar.add_compare_btn.setEnabled(True)  # type: ignore[attr-defined]
+        self.sidebar.enable_post_run_buttons()  # type: ignore[attr-defined]
 
     def _finish_or_chain(self, then_chain: list[int] | None, status_msg: str) -> None:
         """Either chain to the next exercise or finalize the run."""
@@ -242,9 +230,8 @@ class OptimizationMixin:
         with self._opt_lock:  # type: ignore[attr-defined]
             self._opt_running = False  # type: ignore[attr-defined]
         self.sidebar.show_idle()  # type: ignore[attr-defined]
-        self.sidebar.prog_label.setText("Cancelled")  # type: ignore[attr-defined]
+        self.sidebar.set_cancelled()  # type: ignore[attr-defined]
         self.status_label.setText("Optimization cancelled by user.")  # type: ignore[attr-defined]
-        self.sidebar.cancel_btn.setEnabled(True)  # type: ignore[attr-defined]
 
     def _update_result_summary(
         self, name: str, r: OptimizationResult, exercise_type: str = "squat"
@@ -267,7 +254,7 @@ class OptimizationMixin:
                 f"  COM sway: {r.com_horizontal_range_cm:.1f} cm\n"
                 f"  Balance: {balance_ok}"
             )
-        self.sidebar.result_label.setText(  # type: ignore[attr-defined]
+        self.sidebar.set_result_label(  # type: ignore[attr-defined]
             f"{name} results:\n{joint_lines}\n  Work: {work:>6.0f} J"
         )
 

--- a/src/movement_optimizer/gui/parameter_sidebar.py
+++ b/src/movement_optimizer/gui/parameter_sidebar.py
@@ -367,3 +367,64 @@ class ParameterSidebar(QScrollArea):
         self.bar_height_slider.set_value(0.0)
         self.dur_slider.set_value(2.0)
         self.smooth_slider.set_value(1.0)
+
+    # ------------------------------------------------------------------
+    # Façade methods — encapsulate widget-chain access so callers do not
+    # need to traverse into individual child widgets (issue #263 — Law of
+    # Demeter / deep object traversal).
+    # ------------------------------------------------------------------
+
+    def get_optimization_params(self) -> tuple[float, float, float]:
+        """Return ``(bar_kg, duration_s, smoothness)`` from the current slider state."""
+        return (
+            self.bar_slider.value(),
+            self.dur_slider.value(),
+            self.smooth_slider.value(),
+        )
+
+    def get_segment_multipliers(self) -> dict[str, float]:
+        """Return the segment-length multiplier dict from the current slider state."""
+        return {
+            "lower_leg": self.ll_slider.value(),
+            "upper_leg": self.ul_slider.value(),
+            "torso": self.to_slider.value(),
+        }
+
+    def set_progress_done(self, elapsed_str: str, n_evals: int) -> None:
+        """Mark the progress bar as complete and update the label."""
+        self.progress.setValue(100)
+        self.prog_label.setText(f"Done in {elapsed_str} ({n_evals} evals)")
+
+    def set_cancelled(self) -> None:
+        """Update UI to the cancelled state."""
+        self.prog_label.setText("Cancelled")
+        self.cancel_btn.setEnabled(True)
+
+    def set_stall_message(self, msg: str) -> None:
+        """Show *msg* in the stall label."""
+        self.stall_label.setText(msg)
+        self.stall_label.setVisible(True)
+
+    def clear_stall_message(self) -> None:
+        """Hide the stall label."""
+        self.stall_label.setVisible(False)
+
+    def set_result_label(self, text: str) -> None:
+        """Set the result summary text."""
+        self.result_label.setText(text)
+
+    def enable_post_run_buttons(self) -> None:
+        """Enable export/save/compare buttons after a successful run."""
+        self.export_btn.setEnabled(True)
+        self.save_btn.setEnabled(True)
+        self.export_video_btn.setEnabled(True)
+        self.export_plots_btn.setEnabled(True)
+        self.add_compare_btn.setEnabled(True)
+
+    def get_body_params_dict(self) -> dict[str, object]:
+        """Return the current body parameter dict suitable for JSON serialisation."""
+        return {
+            "body_mass": self.mass_slider.value(),
+            "height": self.height_slider.value(),
+            "seg_multipliers": self.get_segment_multipliers(),
+        }

--- a/src/movement_optimizer/models/lagrangian_batch.py
+++ b/src/movement_optimizer/models/lagrangian_batch.py
@@ -1,0 +1,201 @@
+"""Vectorised (batch) inverse-dynamics helpers for the 3-link Lagrangian chain.
+
+These are pure NumPy functions that accept the pre-computed scalar coefficients
+from ``LagrangianDynamics`` rather than a ``self`` reference.  Keeping them
+here separates the *batch computation* concern from the class that owns the
+model parameters.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import NDArray
+
+
+def batch_inertia_torques(
+    qdd: NDArray,
+    c01: NDArray,
+    c02: NDArray,
+    c12: NDArray,
+    *,
+    M00: float,
+    M11: float,
+    M22: float,
+    a01: float,
+    a02: float,
+    a12: float,
+) -> NDArray:
+    """Compute the inertia (mass-matrix) contribution to batch torques.
+
+    Parameters:
+        qdd:  Angular accelerations, shape (N, 3).
+        c01:  cos(q[:,0] - q[:,1]), shape (N,).
+        c02:  cos(q[:,0] - q[:,2]), shape (N,).
+        c12:  cos(q[:,1] - q[:,2]), shape (N,).
+        M00, M11, M22: Diagonal mass-matrix constants.
+        a01, a02, a12: Off-diagonal coupling coefficients.
+
+    Returns:
+        Inertia torque contribution, shape (N, 3).
+    """
+    n = qdd.shape[0]
+    tau = np.empty((n, 3))
+    tau[:, 0] = M00 * qdd[:, 0] + a01 * c01 * qdd[:, 1] + a02 * c02 * qdd[:, 2]
+    tau[:, 1] = a01 * c01 * qdd[:, 0] + M11 * qdd[:, 1] + a12 * c12 * qdd[:, 2]
+    tau[:, 2] = a02 * c02 * qdd[:, 0] + a12 * c12 * qdd[:, 1] + M22 * qdd[:, 2]
+    return tau
+
+
+def batch_coriolis_torques(
+    qd: NDArray,
+    s01: NDArray,
+    s02: NDArray,
+    s12: NDArray,
+    *,
+    a01: float,
+    a02: float,
+    a12: float,
+) -> NDArray:
+    """Compute the centrifugal/Coriolis contribution to batch torques.
+
+    Parameters:
+        qd:  Angular velocities, shape (N, 3).
+        s01: sin(q[:,0] - q[:,1]), shape (N,).
+        s02: sin(q[:,0] - q[:,2]), shape (N,).
+        s12: sin(q[:,1] - q[:,2]), shape (N,).
+        a01, a02, a12: Off-diagonal coupling coefficients.
+
+    Returns:
+        Coriolis torque contribution, shape (N, 3).
+    """
+    n = qd.shape[0]
+    tau = np.zeros((n, 3))
+    tau[:, 0] = a01 * s01 * qd[:, 1] ** 2 + a02 * s02 * qd[:, 2] ** 2
+    tau[:, 1] = -a01 * s01 * qd[:, 0] ** 2 + a12 * s12 * qd[:, 2] ** 2
+    tau[:, 2] = -a02 * s02 * qd[:, 0] ** 2 - a12 * s12 * qd[:, 1] ** 2
+    return tau
+
+
+def batch_gravity_torques(
+    q: NDArray,
+    *,
+    g0: float,
+    g1: float,
+    g2: float,
+    supine: bool = False,
+) -> NDArray:
+    """Compute the gravity contribution to batch torques.
+
+    Parameters:
+        q: Joint angles, shape (N, 3).
+        g0, g1, g2: Pre-computed gravity torque coefficients.
+        supine: If True, gravity acts perpendicular to the chain axis
+            (lifter is lying down) — uses cos(q) instead of sin(q).
+
+    Returns:
+        Gravity torque contribution, shape (N, 3).
+    """
+    sq = np.cos(q) if supine else np.sin(q)
+    n = q.shape[0]
+    tau = np.zeros((n, 3))
+    tau[:, 0] = g0 * sq[:, 0]
+    tau[:, 1] = g1 * sq[:, 1]
+    tau[:, 2] = g2 * sq[:, 2]
+    return tau
+
+
+def numpy_inverse_dynamics_batch(
+    q: NDArray,
+    qd: NDArray,
+    qdd: NDArray,
+    *,
+    M00: float,
+    M11: float,
+    M22: float,
+    a01: float,
+    a02: float,
+    a12: float,
+    g0: float,
+    g1: float,
+    g2: float,
+    supine: bool = False,
+) -> NDArray:
+    """NumPy batch inverse dynamics for a 3-link Lagrangian chain.
+
+    Fuses inertia, Coriolis, and gravity contributions into a single
+    pre-allocated output array to minimise intermediate allocations.
+
+    Parameters:
+        q, qd, qdd: Joint angles/velocities/accelerations, shape (N, 3).
+        M00, M11, M22: Diagonal mass-matrix constants.
+        a01, a02, a12: Off-diagonal coupling coefficients.
+        g0, g1, g2: Gravity torque coefficients.
+        supine: If True uses cos(q) for gravity (bench-press orientation).
+
+    Returns:
+        torques: shape (N, 3).
+    """
+    q0 = q[:, 0]
+    q1 = q[:, 1]
+    q2 = q[:, 2]
+
+    d01 = q0 - q1
+    d02 = q0 - q2
+    d12 = q1 - q2
+
+    tau = np.empty((q.shape[0], 3))
+
+    c01 = np.cos(d01)
+    c02 = np.cos(d02)
+    c12 = np.cos(d12)
+
+    s01 = np.sin(d01)
+    s02 = np.sin(d02)
+    s12 = np.sin(d12)
+
+    qd2_0 = qd[:, 0] ** 2
+    qd2_1 = qd[:, 1] ** 2
+    qd2_2 = qd[:, 2] ** 2
+
+    qdd_0 = qdd[:, 0]
+    qdd_1 = qdd[:, 1]
+    qdd_2 = qdd[:, 2]
+
+    a01_c01 = a01 * c01
+    a02_c02 = a02 * c02
+    a12_c12 = a12 * c12
+
+    a01_s01 = a01 * s01
+    a02_s02 = a02 * s02
+    a12_s12 = a12 * s12
+
+    sq0 = np.cos(q0) if supine else np.sin(q0)
+    sq1 = np.cos(q1) if supine else np.sin(q1)
+    sq2 = np.cos(q2) if supine else np.sin(q2)
+
+    tau[:, 0] = (
+        M00 * qdd_0
+        + a01_c01 * qdd_1
+        + a02_c02 * qdd_2
+        + a01_s01 * qd2_1
+        + a02_s02 * qd2_2
+        + g0 * sq0
+    )
+    tau[:, 1] = (
+        a01_c01 * qdd_0
+        + M11 * qdd_1
+        + a12_c12 * qdd_2
+        - a01_s01 * qd2_0
+        + a12_s12 * qd2_2
+        + g1 * sq1
+    )
+    tau[:, 2] = (
+        a02_c02 * qdd_0
+        + a12_c12 * qdd_1
+        + M22 * qdd_2
+        - a02_s02 * qd2_0
+        - a12_s12 * qd2_1
+        + g2 * sq2
+    )
+
+    return tau

--- a/src/movement_optimizer/models/lagrangian_dynamics.py
+++ b/src/movement_optimizer/models/lagrangian_dynamics.py
@@ -15,6 +15,12 @@ from numpy.typing import NDArray
 from ..backend import PhysicsBackend
 from .body_model import BodyModel, ChainGeometry
 from .lagrangian_balance import _standing_balanced, balance_pose
+from .lagrangian_batch import (
+    batch_coriolis_torques,
+    batch_gravity_torques,
+    batch_inertia_torques,
+    numpy_inverse_dynamics_batch,
+)
 from .lagrangian_kinematics import LagrangianKinematicsMixin
 
 logger = logging.getLogger(__name__)
@@ -221,28 +227,19 @@ class LagrangianDynamics(LagrangianKinematicsMixin, PhysicsBackend):
         c02: NDArray,
         c12: NDArray,
     ) -> NDArray:
-        """Compute the inertia (mass-matrix) contribution to batch torques.
-
-        Parameters:
-            qdd:  Angular accelerations, shape (N, 3).
-            c01:  cos(q[:,0] - q[:,1]), shape (N,).
-            c02:  cos(q[:,0] - q[:,2]), shape (N,).
-            c12:  cos(q[:,1] - q[:,2]), shape (N,).
-        Returns:
-            Inertia torque contribution, shape (N, 3).
-        """
-        n = qdd.shape[0]
-        tau = np.empty((n, 3))
-        tau[:, 0] = (
-            self._M00 * qdd[:, 0] + self._a01 * c01 * qdd[:, 1] + self._a02 * c02 * qdd[:, 2]
+        """Inertia contribution — delegates to :func:`lagrangian_batch.batch_inertia_torques`."""
+        return batch_inertia_torques(
+            qdd,
+            c01,
+            c02,
+            c12,
+            M00=self._M00,
+            M11=self._M11,
+            M22=self._M22,
+            a01=self._a01,
+            a02=self._a02,
+            a12=self._a12,
         )
-        tau[:, 1] = (
-            self._a01 * c01 * qdd[:, 0] + self._M11 * qdd[:, 1] + self._a12 * c12 * qdd[:, 2]
-        )
-        tau[:, 2] = (
-            self._a02 * c02 * qdd[:, 0] + self._a12 * c12 * qdd[:, 1] + self._M22 * qdd[:, 2]
-        )
-        return tau
 
     def _batch_coriolis_torques(
         self,
@@ -251,119 +248,44 @@ class LagrangianDynamics(LagrangianKinematicsMixin, PhysicsBackend):
         s02: NDArray,
         s12: NDArray,
     ) -> NDArray:
-        """Compute the centrifugal/Coriolis contribution to batch torques.
-
-        Parameters:
-            qd:  Angular velocities, shape (N, 3).
-            s01: sin(q[:,0] - q[:,1]), shape (N,).
-            s02: sin(q[:,0] - q[:,2]), shape (N,).
-            s12: sin(q[:,1] - q[:,2]), shape (N,).
-        Returns:
-            Coriolis torque contribution, shape (N, 3).
-        """
-        n = qd.shape[0]
-        tau = np.zeros((n, 3))
-        tau[:, 0] = self._a01 * s01 * qd[:, 1] ** 2 + self._a02 * s02 * qd[:, 2] ** 2
-        tau[:, 1] = -self._a01 * s01 * qd[:, 0] ** 2 + self._a12 * s12 * qd[:, 2] ** 2
-        tau[:, 2] = -self._a02 * s02 * qd[:, 0] ** 2 - self._a12 * s12 * qd[:, 1] ** 2
-        return tau
+        """Coriolis contribution — delegates to :func:`lagrangian_batch.batch_coriolis_torques`."""
+        return batch_coriolis_torques(
+            qd,
+            s01,
+            s02,
+            s12,
+            a01=self._a01,
+            a02=self._a02,
+            a12=self._a12,
+        )
 
     def _batch_gravity_torques(self, q: NDArray) -> NDArray:
-        """Compute the gravity contribution to batch torques.
-
-        Parameters:
-            q: Joint angles, shape (N, 3).
-        Returns:
-            Gravity torque contribution, shape (N, 3).
-        """
-        # Supine (bench press): gravity perpendicular to chain → cos(q)
-        sq = np.cos(q) if self.supine else np.sin(q)
-        n = q.shape[0]
-        tau = np.zeros((n, 3))
-        tau[:, 0] = self._g0 * sq[:, 0]
-        tau[:, 1] = self._g1 * sq[:, 1]
-        tau[:, 2] = self._g2 * sq[:, 2]
-        return tau
+        """Gravity contribution — delegates to :func:`lagrangian_batch.batch_gravity_torques`."""
+        return batch_gravity_torques(
+            q,
+            g0=self._g0,
+            g1=self._g1,
+            g2=self._g2,
+            supine=self.supine,
+        )
 
     def _numpy_inverse_dynamics_batch(self, q: NDArray, qd: NDArray, qdd: NDArray) -> NDArray:
-        """NumPy fallback for batch inverse dynamics (no Rust extension).
-
-        Parameters:
-            q, qd, qdd: shape (N, 3)
-        Returns:
-            torques: shape (N, 3)
-        """
-        q0 = q[:, 0]
-        q1 = q[:, 1]
-        q2 = q[:, 2]
-
-        d01 = q0 - q1
-        d02 = q0 - q2
-        d12 = q1 - q2
-
-        # PERFORMANCE OPTIMISATION:
-        # Fusing the inertia, Coriolis, and gravity torque computations into a single
-        # pre-allocated array assignment. This avoids the creation of multiple
-        # intermediate (N, 3) arrays and redundant loop iterations, reducing
-        # batch evaluation time by ~20-30%.
-
-        # Pre-allocate output array
-        tau = np.empty((q.shape[0], 3))
-
-        c01 = np.cos(d01)
-        c02 = np.cos(d02)
-        c12 = np.cos(d12)
-
-        s01 = np.sin(d01)
-        s02 = np.sin(d02)
-        s12 = np.sin(d12)
-
-        qd2_0 = qd[:, 0] ** 2
-        qd2_1 = qd[:, 1] ** 2
-        qd2_2 = qd[:, 2] ** 2
-
-        qdd_0 = qdd[:, 0]
-        qdd_1 = qdd[:, 1]
-        qdd_2 = qdd[:, 2]
-
-        a01_c01 = self._a01 * c01
-        a02_c02 = self._a02 * c02
-        a12_c12 = self._a12 * c12
-
-        a01_s01 = self._a01 * s01
-        a02_s02 = self._a02 * s02
-        a12_s12 = self._a12 * s12
-
-        sq0 = np.cos(q0) if self.supine else np.sin(q0)
-        sq1 = np.cos(q1) if self.supine else np.sin(q1)
-        sq2 = np.cos(q2) if self.supine else np.sin(q2)
-
-        tau[:, 0] = (
-            self._M00 * qdd_0
-            + a01_c01 * qdd_1
-            + a02_c02 * qdd_2
-            + a01_s01 * qd2_1
-            + a02_s02 * qd2_2
-            + self._g0 * sq0
+        """NumPy fallback — delegates to :func:`lagrangian_batch.numpy_inverse_dynamics_batch`."""
+        return numpy_inverse_dynamics_batch(
+            q,
+            qd,
+            qdd,
+            M00=self._M00,
+            M11=self._M11,
+            M22=self._M22,
+            a01=self._a01,
+            a02=self._a02,
+            a12=self._a12,
+            g0=self._g0,
+            g1=self._g1,
+            g2=self._g2,
+            supine=self.supine,
         )
-        tau[:, 1] = (
-            a01_c01 * qdd_0
-            + self._M11 * qdd_1
-            + a12_c12 * qdd_2
-            - a01_s01 * qd2_0
-            + a12_s12 * qd2_2
-            + self._g1 * sq1
-        )
-        tau[:, 2] = (
-            a02_c02 * qdd_0
-            + a12_c12 * qdd_1
-            + self._M22 * qdd_2
-            - a02_s02 * qd2_0
-            - a12_s12 * qd2_1
-            + self._g2 * sq2
-        )
-
-        return tau
 
     def inverse_dynamics_batch(self, q: NDArray, qd: NDArray, qdd: NDArray) -> NDArray:
         """Vectorised batch torques (N, 3) for q/qd/qdd each (N, 3).


### PR DESCRIPTION
## Summary

- **Issue #263 (deep object traversal):** Add 8 façade methods to `ParameterSidebar` (`get_optimization_params`, `get_segment_multipliers`, `set_progress_done`, `set_cancelled`, `set_stall_message`, `clear_stall_message`, `set_result_label`, `enable_post_run_buttons`, `get_body_params_dict`). Callers in `optimization_mixin.py` and `file_operations.py` now stop at a single boundary instead of reaching into widget sub-attributes three levels deep (Law of Demeter).
- **Issue #262 (split oversized module):** Extract the four batch computation helpers from `LagrangianDynamics` into a new `lagrangian_batch.py` module as pure functions accepting scalar coefficients. `LagrangianDynamics` delegates to these functions, separating the batch-computation concern from parameter ownership. `lagrangian_dynamics.py` drops from ~400 to ~250 lines.

Closes #262
Closes #263

## Test plan

- [ ] Verify `LagrangianDynamics.inverse_dynamics_batch` still returns correct torques (delegate chain unchanged)
- [ ] Verify `ParameterSidebar` façade methods return expected values from underlying widgets
- [ ] Run existing GUI integration smoke tests
- [ ] Confirm `lagrangian_batch` functions are importable standalone

🤖 Generated with [Claude Code](https://claude.com/claude-code)