### PR TITLE
fix: add upper bounds to production dependencies (closes #344)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,10 +10,10 @@ readme = "README.md"
 license = {text = "MIT"}
 requires-python = ">=3.10"
 dependencies = [
-    "numpy>=1.24",
-    "scipy>=1.10",
-    "matplotlib>=3.7",
-    "PyQt6>=6.5",
+    "numpy>=1.24,<2.0",
+    "scipy>=1.10,<2.0",
+    "matplotlib>=3.7,<4.0",
+    "PyQt6>=6.5,<7.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Closes #344

## Problem

pyproject.toml declared production dependencies with only lower bounds (e.g., numpy>=1.24, scipy>=1.10, matplotlib>=3.7, PyQt6>=6.5). Future major releases of these packages could introduce breaking API changes and silently break fresh installs.

## Change

Adds upper bounds using caret-style constraints:

- numpy>=1.24,<2.0
- scipy>=1.10,<2.0
- matplotlib>=3.7,<4.0
- PyQt6>=6.5,<7.0

No code changes — should pass existing CI.