### PR TITLE
build: add docker-compose.yml for local container orchestration (#336)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+services:
+  movement-optimizer:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: movement-optimizer:latest
+    container_name: movement-optimizer
+    volumes:
+      - ./data:/app/data:ro
+      - ./results:/app/results
+    environment:
+      - PYTHONUNBUFFERED=1
+    # Override default entrypoint to keep container alive for exec
+    # or pass CLI arguments directly
+    # Example: docker compose run --rm movement-optimizer --input data/run.json
+    entrypoint: ["python3", "-m", "movement_optimizer.cli"]
+    command: ["--help"]


### PR DESCRIPTION
Fixes #336

Adds a docker-compose.yml that pairs with the existing Dockerfile to enable one-command local builds and runs.

**Usage:**


**Includes:**
- Build context pointing to the existing Dockerfile
- Bind mounts for  (read-only) and  directories
-  for immediate log output
- Configurable entrypoint and command for CLI overrides