### PR TITLE
ci: fix invalid GitHub Actions versions

### DIFF
--- a/.github/workflows/Jules-Control-Tower.yml
+++ b/.github/workflows/Jules-Control-Tower.yml
@@ -59,7 +59,7 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with: { fetch-depth: 0 }
       - uses: google/jules-editor@beta
         with:
@@ -79,7 +79,7 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with: { fetch-depth: 0 }
       - uses: google/jules-editor@beta
         with:
@@ -99,7 +99,7 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with: { fetch-depth: 0 }
       - uses: google/jules-editor@beta
         with:
@@ -119,7 +119,7 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with: { fetch-depth: 0 }
       - uses: google/jules-editor@beta
         with:
@@ -139,7 +139,7 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with: { fetch-depth: 0 }
       - uses: google/jules-editor@beta
         with:
@@ -159,7 +159,7 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with: { fetch-depth: 0 }
       - uses: google/jules-editor@beta
         with:
@@ -179,7 +179,7 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with: { fetch-depth: 0 }
       - uses: google/jules-editor@beta
         with:
@@ -200,7 +200,7 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with: { fetch-depth: 0 }
       - uses: actions/github-script@v7
         id: find-issues
@@ -237,7 +237,7 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with: { fetch-depth: 0 }
       - uses: actions/github-script@v7
         id: find-prs

--- a/.github/workflows/Jules-Issue-Resolver.yml
+++ b/.github/workflows/Jules-Issue-Resolver.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with: { fetch-depth: 0 }
 
       - name: Gather target issues

--- a/.github/workflows/Jules-PR-Compiler.yml
+++ b/.github/workflows/Jules-PR-Compiler.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with: { fetch-depth: 0 }
 
       - name: Gather open Jules PRs

--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -29,9 +29,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with: {fetch-depth: 0}
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v5
         with: {python-version: "3.12"}
 
       - name: Install System Dependencies
@@ -78,8 +78,8 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with: {python-version: "${{ matrix.python-version }}"}
 
       - name: Install System Dependencies
@@ -103,7 +103,7 @@ jobs:
 
       - name: Upload Coverage
         if: matrix.python-version == '3.12'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-report
           path: coverage.xml
@@ -112,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
       - name: Check for Rust changes
         id: rust-changes

--- a/src/movement_optimizer/trajectory/optimizer_packaging.py
+++ b/src/movement_optimizer/trajectory/optimizer_packaging.py
@@ -159,7 +159,7 @@ def build_result_object(
         elapsed >= 0
     """
     cost_val = float(res.fun)  # type: ignore[attr-defined]
-    com_h_range = (np.max(com_x) - np.min(com_x)) * 100.0
+    com_h_range = float((np.max(com_x) - np.min(com_x)) * 100.0)
     return OptimizationResult(
         t=t_eval,
         q=q,


### PR DESCRIPTION
Fixes invalid GitHub Actions versions in CI workflow files:
- actions/checkout@v6 → v4
- actions/setup-python@v6 → v5
- actions/upload-artifact@v7 → v4

These non-existent versions were causing CI failures in the quality-gate job. Using valid versions restores CI pass rate.