### PR TITLE
fix: enforce local-only runner routing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Workflow changes require maintainer review to prevent agent regressions
+.github/workflows/ @dieterolson
+.github/CODEOWNERS @dieterolson
+scripts/check_local_only_workflows.py @dieterolson

--- a/.github/workflows/Comment-to-Issue-Converter.yml
+++ b/.github/workflows/Comment-to-Issue-Converter.yml
@@ -25,7 +25,7 @@ jobs:
             echo "Self-hosted runner online — routing locally"
           else
             echo "runner=d-sorg-fleet" >> $GITHUB_OUTPUT
-            echo "No self-hosted runner — using GitHub-hosted"
+            echo "No self-hosted runner — using cloud runner (blocked)"
           fi
   convert-comment:
     needs: pick-runner

--- a/.github/workflows/Comment-to-Issue-Converter.yml
+++ b/.github/workflows/Comment-to-Issue-Converter.yml
@@ -24,7 +24,7 @@ jobs:
             echo "runner=d-sorg-fleet" >> $GITHUB_OUTPUT
             echo "Self-hosted runner online — routing locally"
           else
-            echo "runner=ubuntu-latest" >> $GITHUB_OUTPUT
+            echo "runner=d-sorg-fleet" >> $GITHUB_OUTPUT
             echo "No self-hosted runner — using GitHub-hosted"
           fi
   convert-comment:

--- a/.github/workflows/Jules-Control-Tower.yml
+++ b/.github/workflows/Jules-Control-Tower.yml
@@ -47,7 +47,7 @@ jobs:
             echo "runner=d-sorg-fleet" >> $GITHUB_OUTPUT
             echo "Self-hosted runner online — routing locally"
           else
-            echo "runner=ubuntu-latest" >> $GITHUB_OUTPUT
+            echo "runner=d-sorg-fleet" >> $GITHUB_OUTPUT
             echo "No self-hosted runner — using GitHub-hosted"
           fi
   auto-repair:

--- a/.github/workflows/Jules-Control-Tower.yml
+++ b/.github/workflows/Jules-Control-Tower.yml
@@ -48,7 +48,7 @@ jobs:
             echo "Self-hosted runner online — routing locally"
           else
             echo "runner=d-sorg-fleet" >> $GITHUB_OUTPUT
-            echo "No self-hosted runner — using GitHub-hosted"
+            echo "No self-hosted runner — using cloud runner (blocked)"
           fi
   auto-repair:
     needs: pick-runner

--- a/.github/workflows/Jules-Issue-Resolver.yml
+++ b/.github/workflows/Jules-Issue-Resolver.yml
@@ -41,7 +41,7 @@ jobs:
             echo "Self-hosted runner online — routing locally"
           else
             echo "runner=d-sorg-fleet" >> $GITHUB_OUTPUT
-            echo "No self-hosted runner — using GitHub-hosted"
+            echo "No self-hosted runner — using cloud runner (blocked)"
           fi
   resolve-issues:
     needs: pick-runner

--- a/.github/workflows/Jules-Issue-Resolver.yml
+++ b/.github/workflows/Jules-Issue-Resolver.yml
@@ -40,7 +40,7 @@ jobs:
             echo "runner=d-sorg-fleet" >> $GITHUB_OUTPUT
             echo "Self-hosted runner online — routing locally"
           else
-            echo "runner=ubuntu-latest" >> $GITHUB_OUTPUT
+            echo "runner=d-sorg-fleet" >> $GITHUB_OUTPUT
             echo "No self-hosted runner — using GitHub-hosted"
           fi
   resolve-issues:

--- a/.github/workflows/Jules-PR-Compiler.yml
+++ b/.github/workflows/Jules-PR-Compiler.yml
@@ -33,7 +33,7 @@ jobs:
             echo "runner=d-sorg-fleet" >> $GITHUB_OUTPUT
             echo "Self-hosted runner online — routing locally"
           else
-            echo "runner=ubuntu-latest" >> $GITHUB_OUTPUT
+            echo "runner=d-sorg-fleet" >> $GITHUB_OUTPUT
             echo "No self-hosted runner — using GitHub-hosted"
           fi
   compile-prs:

--- a/.github/workflows/Jules-PR-Compiler.yml
+++ b/.github/workflows/Jules-PR-Compiler.yml
@@ -34,7 +34,7 @@ jobs:
             echo "Self-hosted runner online — routing locally"
           else
             echo "runner=d-sorg-fleet" >> $GITHUB_OUTPUT
-            echo "No self-hosted runner — using GitHub-hosted"
+            echo "No self-hosted runner — using cloud runner (blocked)"
           fi
   compile-prs:
     needs: pick-runner

--- a/.github/workflows/ci-failure-digest.yml
+++ b/.github/workflows/ci-failure-digest.yml
@@ -25,7 +25,7 @@ jobs:
             echo "runner=d-sorg-fleet" >> $GITHUB_OUTPUT
             echo "Self-hosted runner online — routing locally"
           else
-            echo "runner=ubuntu-latest" >> $GITHUB_OUTPUT
+            echo "runner=d-sorg-fleet" >> $GITHUB_OUTPUT
             echo "No self-hosted runner — using GitHub-hosted"
           fi
   failure-digest:

--- a/.github/workflows/ci-failure-digest.yml
+++ b/.github/workflows/ci-failure-digest.yml
@@ -26,7 +26,7 @@ jobs:
             echo "Self-hosted runner online — routing locally"
           else
             echo "runner=d-sorg-fleet" >> $GITHUB_OUTPUT
-            echo "No self-hosted runner — using GitHub-hosted"
+            echo "No self-hosted runner — using cloud runner (blocked)"
           fi
   failure-digest:
     needs: pick-runner

--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   pick-runner:
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     timeout-minutes: 2
     outputs:
       runner: ${{ steps.check.outputs.runner }}
@@ -24,9 +24,9 @@ jobs:
         id: check
         env:
           GH_TOKEN: ${{ secrets.RUNNER_CHECK_TOKEN }}
-        run: "echo \"runner=ubuntu-latest\" >> $GITHUB_OUTPUT"
+        run: "echo \"runner=d-sorg-fleet\" >> $GITHUB_OUTPUT"
   quality-gate:
-    runs-on: ubuntu-latest
+    runs-on: ${{ needs.pick-runner.outputs.runner }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
@@ -36,12 +36,20 @@ jobs:
 
       - name: Install System Dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y libegl1 xvfb
+          if command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+            sudo apt-get update
+            sudo apt-get install -y libegl1 xvfb
+          else
+            echo "Using preinstalled deps on self-hosted runner"
+          fi
 
       - name: Install Dependencies
         run: |
-          sudo apt-get update && sudo apt-get install -y libegl1
+          if command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+            sudo apt-get update && sudo apt-get install -y libegl1
+          else
+            echo "Using preinstalled deps on self-hosted runner"
+          fi
           python -m venv .ci-venv
           . .ci-venv/bin/activate
           python -m pip install --upgrade pip
@@ -72,7 +80,7 @@ jobs:
     needs:
       - pick-runner
       - quality-gate
-    runs-on: ubuntu-latest
+    runs-on: ${{ needs.pick-runner.outputs.runner }}
     timeout-minutes: 15
     strategy:
       matrix:
@@ -84,12 +92,20 @@ jobs:
 
       - name: Install System Dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y libegl1 xvfb
+          if command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+            sudo apt-get update
+            sudo apt-get install -y libegl1 xvfb
+          else
+            echo "Using preinstalled deps on self-hosted runner"
+          fi
 
       - name: Install Dependencies
         run: |
-          sudo apt-get update && sudo apt-get install -y libegl1
+          if command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+            sudo apt-get update && sudo apt-get install -y libegl1
+          else
+            echo "Using preinstalled deps on self-hosted runner"
+          fi
           python -m venv .ci-venv
           . .ci-venv/bin/activate
           python -m pip install --upgrade pip
@@ -109,7 +125,7 @@ jobs:
           path: coverage.xml
 
   rust-quality-gate:
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -4,7 +4,7 @@ on:
     branches: [main]
 jobs:
   dco:
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/local-only-runner-guard.yml
+++ b/.github/workflows/local-only-runner-guard.yml
@@ -1,0 +1,43 @@
+name: Local-Only Workflow Runner Guard
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+      - "scripts/check_local_only_workflows.py"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/**"
+      - "scripts/check_local_only_workflows.py"
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  local-only-workflows:
+    name: Reject hosted runner routing
+    runs-on: d-sorg-fleet
+    steps:
+      - name: Checkout repository without external actions
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          auth_header="$(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\n')"
+          git init "$GITHUB_WORKSPACE"
+          cd "$GITHUB_WORKSPACE"
+          git remote remove origin 2>/dev/null || true
+          git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${auth_header}" fetch --depth=1 origin "$GITHUB_SHA"
+          git checkout --force FETCH_HEAD
+          git clean -ffdx
+      - name: Run local-only workflow guard
+        shell: bash
+        run: |
+          set -euo pipefail
+          if command -v python3 >/dev/null 2>&1; then
+            python3 scripts/check_local_only_workflows.py
+          else
+            python scripts/check_local_only_workflows.py
+          fi
+

--- a/.github/workflows/pr-auto-labeler.yml
+++ b/.github/workflows/pr-auto-labeler.yml
@@ -25,7 +25,7 @@ jobs:
             echo "Self-hosted runner online — routing locally"
           else
             echo "runner=d-sorg-fleet" >> $GITHUB_OUTPUT
-            echo "No self-hosted runner — using GitHub-hosted"
+            echo "No self-hosted runner — using cloud runner (blocked)"
           fi
   label:
     needs: pick-runner

--- a/.github/workflows/pr-auto-labeler.yml
+++ b/.github/workflows/pr-auto-labeler.yml
@@ -24,7 +24,7 @@ jobs:
             echo "runner=d-sorg-fleet" >> $GITHUB_OUTPUT
             echo "Self-hosted runner online — routing locally"
           else
-            echo "runner=ubuntu-latest" >> $GITHUB_OUTPUT
+            echo "runner=d-sorg-fleet" >> $GITHUB_OUTPUT
             echo "No self-hosted runner — using GitHub-hosted"
           fi
   label:

--- a/.github/workflows/stale-cleanup.yml
+++ b/.github/workflows/stale-cleanup.yml
@@ -26,7 +26,7 @@ jobs:
             echo "Self-hosted runner online — routing locally"
           else
             echo "runner=d-sorg-fleet" >> $GITHUB_OUTPUT
-            echo "No self-hosted runner — using GitHub-hosted"
+            echo "No self-hosted runner — using cloud runner (blocked)"
           fi
   stale:
     needs: pick-runner

--- a/.github/workflows/stale-cleanup.yml
+++ b/.github/workflows/stale-cleanup.yml
@@ -25,7 +25,7 @@ jobs:
             echo "runner=d-sorg-fleet" >> $GITHUB_OUTPUT
             echo "Self-hosted runner online — routing locally"
           else
-            echo "runner=ubuntu-latest" >> $GITHUB_OUTPUT
+            echo "runner=d-sorg-fleet" >> $GITHUB_OUTPUT
             echo "No self-hosted runner — using GitHub-hosted"
           fi
   stale:

--- a/scripts/check_local_only_workflows.py
+++ b/scripts/check_local_only_workflows.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Fail when GitHub Actions workflows can route to hosted runners."""
+from __future__ import annotations
+from pathlib import Path
+
+WORKFLOW_DIR = Path(".github") / "workflows"
+BANNED = (
+    "ubuntu-latest", "windows-latest", "macos-latest",
+    "force_cloud", "mode=cloud",
+    "Routing to GitHub-hosted", "using GitHub-hosted",
+    "runner=ubuntu-latest", "runner=windows-latest", "runner=macos-latest",
+)
+
+def main() -> int:
+    failures: list[str] = []
+    if not WORKFLOW_DIR.exists():
+        return 0
+    for path in sorted(WORKFLOW_DIR.rglob("*")):
+        if path.suffix not in {".yml", ".yaml"}:
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            text = path.read_text(encoding="utf-8-sig")
+        for line_number, line in enumerate(text.splitlines(), start=1):
+            for token in BANNED:
+                if token in line:
+                    failures.append(f"{path}:{line_number}: banned hosted-runner token {token!r}")
+    if failures:
+        print("GitHub-hosted runner routing is forbidden. Use local self-hosted runners only.")
+        print("\n".join(failures))
+        return 1
+    print("Workflow runner routing is local-only.")
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+


### PR DESCRIPTION
## Summary
- Replace all ubuntu-latest/windows-latest runs-on: values with d-sorg-fleet across all 9 workflow files
- Remove pick-runner fallback logic (runner=ubuntu-latest) that allowed GitHub-hosted routing
- Fix quality-gate job that had a hardcoded runs-on: ubuntu-latest instead of using pick-runner output
- Wrap sudo apt-get blocks with availability guards so they degrade gracefully on self-hosted runners
- Add scripts/check_local_only_workflows.py and .github/workflows/local-only-runner-guard.yml to enforce the policy going forward

## Test plan
- [ ] Verify all runs-on: values reference only d-sorg-fleet or needs.pick-runner.outputs.runner
- [ ] Confirm local-only-runner-guard CI job passes on this PR
- [ ] Confirm CI Standard pipeline runs end-to-end on self-hosted runner

Generated with Claude Code