### PR TITLE
ci: persist .coverage file and generate HTML coverage report (#317)

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -122,7 +122,22 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: coverage-report
-          path: coverage.xml
+          path: |
+            coverage.xml
+            .coverage
+
+      - name: Generate HTML Coverage Report
+        if: matrix.python-version == '3.12'
+        run: |
+          python -m coverage html --directory=htmlcov
+          echo "HTML coverage report generated at htmlcov/index.html"
+
+      - name: Upload HTML Coverage Report
+        if: matrix.python-version == '3.12'
+        uses: actions/upload-artifact@v4
+        with:
+          name: html-coverage-report
+          path: htmlcov/
 
   rust-quality-gate:
     runs-on: d-sorg-fleet


### PR DESCRIPTION
## Summary

Fixes #317 by ensuring the `.coverage` binary database file is persisted as a CI artifact alongside the XML report, and by generating an HTML coverage report for easier inspection.

## Problem
The CI workflow generated `coverage.xml` but only uploaded it as an artifact. The `.coverage` binary database (used by tools like `coverage combine`, IDE plugins, and coverage-badge) was not persisted, making it impossible for downstream workflows to consume or for developers to inspect line-by-line coverage locally.

## Changes
1. **Updated artifact upload step** to include both `coverage.xml` AND `.coverage`
2. **Added HTML coverage report generation** using `coverage html`
3. **Added HTML coverage report artifact upload** for easy browser-based inspection

## Checklist
- [x] YAML workflow validated
- [x] Commits follow conventional commit format
- [x] Coverage data now available in multiple formats