### PR TITLE
feat: add health endpoint to CLI

### DIFF
--- a/src/movement_optimizer/cli.py
+++ b/src/movement_optimizer/cli.py
@@ -99,6 +99,11 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     _add_body_args(parser)
     _add_run_args(parser)
+    parser.add_argument(
+        "--health",
+        action="store_true",
+        help="Emit a JSON health report and exit.",
+    )
     return parser
 
 
@@ -308,6 +313,10 @@ def main(argv: list[str] | None = None) -> int:
     """
     parser = _build_parser()
     args = parser.parse_args(argv)
+    if args.health:
+        from .health import health_check
+        print(health_check().to_json())
+        return 0
     _validate_cli_args(parser, args)
     _configure_logging(args.verbose)
     body = BodyModel(body_mass=args.body_mass, height=args.height)

--- a/src/movement_optimizer/health.py
+++ b/src/movement_optimizer/health.py
@@ -1,0 +1,74 @@
+"""Health endpoint for Movement-Optimizer.
+
+Provides a lightweight, side-effect-free health check that reports
+package version, critical dependency availability, and a basic
+physics-solver sanity check.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+import json
+import sys
+import time
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class HealthStatus:
+    """Immutable health status snapshot."""
+
+    status: str
+    version: str
+    python_version: str
+    timestamp: float = field(default_factory=time.time)
+    checks: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a plain dictionary representation."""
+        return asdict(self)
+
+    def to_json(self, indent: int | None = None) -> str:
+        """Serialize to JSON string."""
+        return json.dumps(self.to_dict(), indent=indent)
+
+
+def health_check() -> HealthStatus:
+    """Run dependency and sanity checks.
+
+    Postcondition:
+        Returns HealthStatus with status == "ok" iff all checks pass.
+    """
+    version = "unknown"
+    try:
+        version = importlib.metadata.version("movement-optimizer")
+    except importlib.metadata.PackageNotFoundError:
+        pass
+
+    checks: dict[str, Any] = {}
+
+    # Check numpy (required for all trajectory math)
+    try:
+        import numpy as np  # noqa: F401
+
+        checks["numpy"] = "ok"
+    except ImportError as exc:
+        checks["numpy"] = f"missing: {exc}"
+
+    # Check core physics backend instantiates without error
+    try:
+        from .backend import LagrangianDynamics  # type: ignore[attr-defined]
+
+        _ = LagrangianDynamics()
+        checks["physics_backend"] = "ok"
+    except Exception as exc:  # noqa: BLE001
+        checks["physics_backend"] = f"error: {exc}"
+
+    status = "ok" if all(v == "ok" for v in checks.values()) else "degraded"
+    return HealthStatus(
+        status=status,
+        version=version,
+        python_version=f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}",
+        checks=checks,
+    )

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,31 @@
+"""Tests for movement_optimizer.health."""
+
+import json
+
+from movement_optimizer.health import HealthStatus, health_check
+
+
+def test_health_returns_ok() -> None:
+    """Health check should report ok when deps are present."""
+    result = health_check()
+    assert result.status == "ok"
+    assert result.version == "0.0.0.dev0"  # not installed as package in dev
+    assert result.checks["numpy"] == "ok"
+    assert result.checks["physics_backend"] == "ok"
+
+
+def test_health_json_roundtrip() -> None:
+    """JSON serialization should round-trip cleanly."""
+    result = health_check()
+    parsed = json.loads(result.to_json())
+    assert parsed["status"] == "ok"
+    assert "version" in parsed
+    assert "timestamp" in parsed
+    assert "checks" in parsed
+
+
+def test_health_dict_contains_all_fields() -> None:
+    """to_dict() should expose every field."""
+    result = health_check()
+    d = result.to_dict()
+    assert set(d.keys()) >= {"status", "version", "python_version", "timestamp", "checks"}


### PR DESCRIPTION
Closes #331\n\nAdds:\n- src/movement_optimizer/health.py — HealthStatus dataclass + health_check() function that verifies numpy and instantiates LagrangianDynamics backend.\n- src/movement_optimizer/cli.py — Adds --health flag that emits JSON health report and exits.\n- tests/test_health.py — pytest coverage for happy path, JSON round-trip, and dict serialization.\n\nVerified:\n- python3 -c "import ast; ast.parse(...)" → Syntax OK\n\nDesign choices:\n- CLI flag --health is available on every command invocation for easy CI/ops probing.\n- Backend instantiation check validates the core physics solver without running a full optimization.