### PR TITLE
chore(license): add SPDX-License-Identifier to all Python source files

### DIFF
--- a/src/movement_optimizer/__init__.py
+++ b/src/movement_optimizer/__init__.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2026 D-Sorganization. All rights reserved.
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 D-sorganization
 """Movement Optimizer.
 
 A biomechanics tool for optimising exercise movement trajectories

--- a/src/movement_optimizer/__main__.py
+++ b/src/movement_optimizer/__main__.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2026 D-Sorganization. All rights reserved.
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 D-sorganization
 """Entry point: ``python -m movement_optimizer``."""
 
 from __future__ import annotations

--- a/src/movement_optimizer/backend.py
+++ b/src/movement_optimizer/backend.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2026 D-Sorganization. All rights reserved.
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 D-sorganization
 """Abstract physics backend interface.
 
 Provides a clean abstraction layer so the optimizer can work with

--- a/src/movement_optimizer/cli.py
+++ b/src/movement_optimizer/cli.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2026 D-Sorganization. All rights reserved.
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 D-sorganization
 """CLI for headless batch optimization.
 
 Usage:

--- a/src/movement_optimizer/comparison.py
+++ b/src/movement_optimizer/comparison.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2026 D-Sorganization. All rights reserved.
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 D-sorganization
 """Trial comparison storage and metrics computation.
 
 Allows users to store multiple optimization runs and compare them

--- a/src/movement_optimizer/config.py
+++ b/src/movement_optimizer/config.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2026 D-Sorganization. All rights reserved.
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 D-sorganization
 """Runtime configuration and filesystem paths for Movement Optimizer.
 
 Configuration is intentionally lightweight and environment-driven so local

--- a/src/movement_optimizer/constants.py
+++ b/src/movement_optimizer/constants.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2026 D-Sorganization. All rights reserved.
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 D-sorganization
 """Anthropometric and equipment constants.
 
 Sources:

--- a/src/movement_optimizer/exercises/__init__.py
+++ b/src/movement_optimizer/exercises/__init__.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2026 D-Sorganization. All rights reserved.
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 D-sorganization
 """Exercise configuration factories."""
 
 from .clean import make_clean_config as make_clean_config

--- a/src/movement_optimizer/exercises/_common.py
+++ b/src/movement_optimizer/exercises/_common.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2026 D-Sorganization. All rights reserved.
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 D-sorganization
 """Shared helpers for planar exercise configuration factories."""
 
 from __future__ import annotations

--- a/src/movement_optimizer/exercises/clean.py
+++ b/src/movement_optimizer/exercises/clean.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2026 D-Sorganization. All rights reserved.
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 D-sorganization
 """Clean exercise configuration.
 
 The clean lifts the bar from the floor to front rack (shoulder height).

--- a/src/movement_optimizer/exercises/gait.py
+++ b/src/movement_optimizer/exercises/gait.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2026 D-Sorganization. All rights reserved.
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 D-sorganization
 """Gait (walking) exercise configuration and analysis.
 
 Defines a full gait cycle from right heel strike to next right heel strike.

--- a/src/movement_optimizer/exercises/jerk.py
+++ b/src/movement_optimizer/exercises/jerk.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2026 D-Sorganization. All rights reserved.
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 D-sorganization
 """Jerk exercise configuration.
 
 The jerk drives the bar from front rack (shoulders) to overhead lockout.

--- a/src/movement_optimizer/exercises/sit_to_stand.py
+++ b/src/movement_optimizer/exercises/sit_to_stand.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2026 D-Sorganization. All rights reserved.
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 D-sorganization
 """Sit-to-stand exercise configuration.
 
 Phases: seated -> forward lean (momentum) -> seat-off -> rising -> standing.

--- a/src/movement_optimizer/exercises/snatch.py
+++ b/src/movement_optimizer/exercises/snatch.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2026 D-Sorganization. All rights reserved.
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 D-sorganization
 """Snatch exercise configuration.
 
 The snatch lifts the bar from the floor to overhead in one continuous

--- a/src/movement_optimizer/export.py
+++ b/src/movement_optimizer/export.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2026 D-Sorganization. All rights reserved.
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 D-sorganization
 """Export helpers for animation GIFs and plot images.
 
 Design Principles:

--- a/src/movement_optimizer/gui/__init__.py
+++ b/src/movement_optimizer/gui/__init__.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2026 D-Sorganization. All rights reserved.
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 D-sorganization
 """GUI package for the Movement Optimizer.
 
 The original monolithic ``gui.py`` has been split into a package with

--- a/src/movement_optimizer/gui/anim_renderer.py
+++ b/src/movement_optimizer/gui/anim_renderer.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2026 D-Sorganization. All rights reserved.
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 D-sorganization
 """Animation/kinematic frame rendering for the Movement Optimizer."""
 
 from typing import Any

--- a/src/movement_optimizer/gui/animation_control.py
+++ b/src/movement_optimizer/gui/animation_control.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2026 D-Sorganization. All rights reserved.
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 D-sorganization
 # mypy: disable-error-code="misc,has-type"
 # Mixin pattern: methods annotate self as MainWindow to access its attributes,
 # but mypy cannot verify this pattern without the concrete class in scope.

--- a/src/movement_optimizer/gui/bilateral_3d_renderer.py
+++ b/src/movement_optimizer/gui/bilateral_3d_renderer.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2026 D-Sorganization. All rights reserved.
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 D-sorganization
 """3D Bilateral rendering for the animation canvas.
 
 Renders a :class:`~movement_optimizer.models.Bilateral3DModel` pose onto

--- a/src/movement_optimizer/gui/comparison_dialog.py
+++ b/src/movement_optimizer/gui/comparison_dialog.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2026 D-Sorganization. All rights reserved.
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 D-sorganization
 """ComparisonDialog -- display side-by-side metrics."""
 
 from __future__ import annotations

--- a/src/movement_optimizer/gui/comparison_mixin.py
+++ b/src/movement_optimizer/gui/comparison_mixin.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2026 D-Sorganization. All rights reserved.
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 D-sorganization
 # mypy: disable-error-code="misc,has-type"
 # Mixin pattern: methods annotate self as MainWindow to access its attributes,
 # but mypy cannot verify this pattern without the concrete class in scope.

--- a/src/movement_optimizer/gui/exercise_tab.py
+++ b/src/movement_optimizer/gui/exercise_tab.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2026 D-Sorganization. All rights reserved.
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 D-sorganization
 """ExerciseTab -- individual tab logic for movement visualizations."""
 
 from __future__ import annotations

--- a/src/movement_optimizer/gui/file_operations.py
+++ b/src/movement_optimizer/gui/file_operations.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2026 D-Sorganization. All rights reserved.
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 D-sorganization
 # mypy: disable-error-code="misc,arg-type"
 # Mixin pattern: methods annotate self as MainWindow to access its attributes.
 """File I/O helpers extracted from MainWindow.

--- a/src/movement_optimizer/gui/labelled_slider.py
+++ b/src/movement_optimizer/gui/labelled_slider.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2026 D-Sorganization. All rights reserved.
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 D-sorganization
 """LabelledSlider: a slider widget with a label and formatted value display."""
 
 from __future__ import annotations

--- a/src/movement_optimizer/gui/main_window.py
+++ b/src/movement_optimizer/gui/main_window.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2026 D-Sorganization. All rights reserved.
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 D-sorganization
 """PyQt6 GUI for the Movement Optimizer.
 
 Layout:

--- a/src/movement_optimizer/gui/optimization_mixin.py
+++ b/src/movement_optimizer/gui/optimization_mixin.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2026 D-Sorganization. All rights reserved.
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 D-sorganization
 """Mixin for optimization controller logic in the Movement Optimizer GUI."""
 
 from __future__ import annotations

--- a/src/movement_optimizer/gui/parameter_sidebar.py
+++ b/src/movement_optimizer/gui/parameter_sidebar.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2026 D-Sorganization. All rights reserved.
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 D-sorganization
 """ParameterSidebar: left-hand parameter panel for the main window."""
 
 from __future__ import annotations

--- a/src/movement_optimizer/gui/playback_controls.py
+++ b/src/movement_optimizer/gui/playback_controls.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2026 D-Sorganization. All rights reserved.
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 D-sorganization
 """PlaybackControls: transport bar widget for animation playback."""
 
 from __future__ import annotations

--- a/src/movement_optimizer/gui/plot_renderer.py
+++ b/src/movement_optimizer/gui/plot_renderer.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2026 D-Sorganization. All rights reserved.
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 D-sorganization
 """Static plot renderers for the Movement Optimizer."""
 
 from typing import Any

--- a/src/movement_optimizer/gui/session_state.py
+++ b/src/movement_optimizer/gui/session_state.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2026 D-Sorganization. All rights reserved.
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 D-sorganization
 """Helpers for collecting and restoring GUI session state."""
 
 from __future__ import annotations

--- a/src/movement_optimizer/gui/stylesheet.py
+++ b/src/movement_optimizer/gui/stylesheet.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2026 D-Sorganization. All rights reserved.
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 D-sorganization
 """Application stylesheet."""
 
 from ..rendering import Palette

--- a/src/movement_optimizer/gui/ui_builder.py
+++ b/src/movement_optimizer/gui/ui_builder.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2026 D-Sorganization. All rights reserved.
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 D-sorganization
 """UI construction helpers for the main window."""
 
 from PyQt6.QtCore import Qt

--- a/src/movement_optimizer/gui/widgets.py
+++ b/src/movement_optimizer/gui/widgets.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2026 D-Sorganization. All rights reserved.
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 D-sorganization
 """Reusable GUI widgets.
 
 This module re-exports the three widget classes from their dedicated modules

--- a/src/movement_optimizer/models/__init__.py
+++ b/src/movement_optimizer/models/__init__.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2026 D-Sorganization. All rights reserved.
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 D-sorganization
 """Body model and Lagrangian dynamics engine.
 
 This package contains the anthropometric body model and the analytical

--- a/src/movement_optimizer/models/bench_press_model.py
+++ b/src/movement_optimizer/models/bench_press_model.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2026 D-Sorganization. All rights reserved.
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 D-sorganization
 """Bench press anthropometric model and exercise configuration factory.
 
 Contains ``BenchPressModel`` and ``make_bench_press_config``.

--- a/src/movement_optimizer/models/bilateral_3d.py
+++ b/src/movement_optimizer/models/bilateral_3d.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2026 D-Sorganization. All rights reserved.
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 D-sorganization
 """3D Bilateral forward-kinematics model.
 
 This module provides a minimal-but-correct 3D kinematic model of a human

--- a/src/movement_optimizer/models/body_model.py
+++ b/src/movement_optimizer/models/body_model.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2026 D-Sorganization. All rights reserved.
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 D-sorganization
 """Anthropometric body model and related utilities.
 
 Contains ``BodyModel``, ``ChainGeometry``, and joint-angle helper functions.

--- a/src/movement_optimizer/models/exercise_configs.py
+++ b/src/movement_optimizer/models/exercise_configs.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2026 D-Sorganization. All rights reserved.
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 D-sorganization
 """Exercise configuration factories for squat and deadlift movements.
 
 Contains ``make_squat_config``, ``make_full_squat_config``, and

--- a/src/movement_optimizer/models/lagrangian_balance.py
+++ b/src/movement_optimizer/models/lagrangian_balance.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2026 D-Sorganization. All rights reserved.
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 D-sorganization
 """Balance utilities for the Lagrangian planar-chain dynamics model.
 
 Provides ``balance_pose`` (adjust one joint to land COM at inner BOS center)

--- a/src/movement_optimizer/models/lagrangian_batch.py
+++ b/src/movement_optimizer/models/lagrangian_batch.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2026 D-Sorganization. All rights reserved.
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 D-sorganization
 """Vectorised (batch) inverse-dynamics helpers for the 3-link Lagrangian chain.
 
 These are pure NumPy functions that accept the pre-computed scalar coefficients

--- a/src/movement_optimizer/models/lagrangian_dynamics.py
+++ b/src/movement_optimizer/models/lagrangian_dynamics.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2026 D-Sorganization. All rights reserved.
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 D-sorganization
 """Lagrangian inverse dynamics for a 3-link planar chain.
 
 Contains ``LagrangianDynamics``.  Balance utilities (``balance_pose``,

--- a/src/movement_optimizer/models/lagrangian_kinematics.py
+++ b/src/movement_optimizer/models/lagrangian_kinematics.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2026 D-Sorganization. All rights reserved.
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 D-sorganization
 """Kinematic output methods for the Lagrangian planar-chain model.
 
 ``LagrangianKinematicsMixin`` provides forward kinematics, bar-position

--- a/src/movement_optimizer/persistence.py
+++ b/src/movement_optimizer/persistence.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2026 D-Sorganization. All rights reserved.
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 D-sorganization
 """Persistence layer for saving/loading solutions and app state.
 
 Handles JSON serialization of OptimizationResult objects, including

--- a/src/movement_optimizer/rendering.py
+++ b/src/movement_optimizer/rendering.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2026 D-Sorganization. All rights reserved.
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 D-sorganization
 """Matplotlib rendering helpers for the animation panel.
 
 Separated from the GUI so rendering logic can be tested independently

--- a/src/movement_optimizer/spine_loads.py
+++ b/src/movement_optimizer/spine_loads.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2026 D-Sorganization. All rights reserved.
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 D-sorganization
 """Spinal stress estimation at the L5/S1 joint.
 
 Computes compression and anterior-posterior shear forces at the L5/S1

--- a/src/movement_optimizer/strength.py
+++ b/src/movement_optimizer/strength.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2026 D-Sorganization. All rights reserved.
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 D-sorganization
 """Joint strength models and load-capacity helpers."""
 
 from __future__ import annotations

--- a/src/movement_optimizer/trajectory/__init__.py
+++ b/src/movement_optimizer/trajectory/__init__.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2026 D-Sorganization. All rights reserved.
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 D-sorganization
 """Trajectory module extracted from monolith."""
 
 from __future__ import annotations

--- a/src/movement_optimizer/trajectory/cache.py
+++ b/src/movement_optimizer/trajectory/cache.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2026 D-Sorganization. All rights reserved.
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 D-sorganization
 """Thread-safe cache for optimisation solutions."""
 
 from __future__ import annotations

--- a/src/movement_optimizer/trajectory/optimizer.py
+++ b/src/movement_optimizer/trajectory/optimizer.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2026 D-Sorganization. All rights reserved.
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 D-sorganization
 """Parallel multi-start trajectory optimiser engine."""
 
 from __future__ import annotations

--- a/src/movement_optimizer/trajectory/optimizer_bench.py
+++ b/src/movement_optimizer/trajectory/optimizer_bench.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2026 D-Sorganization. All rights reserved.
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 D-sorganization
 """Bench-press-specific helpers for the trajectory optimiser."""
 
 from __future__ import annotations

--- a/src/movement_optimizer/trajectory/optimizer_constraints.py
+++ b/src/movement_optimizer/trajectory/optimizer_constraints.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2026 D-Sorganization. All rights reserved.
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 D-sorganization
 """Constraint-vector builders for the trajectory optimiser.
 
 These free functions build the inequality-constraint vectors consumed by

--- a/src/movement_optimizer/trajectory/optimizer_cost.py
+++ b/src/movement_optimizer/trajectory/optimizer_cost.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2026 D-Sorganization. All rights reserved.
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 D-sorganization
 """Pure cost-term functions for the trajectory optimiser.
 
 Each function computes one additive term of the total optimisation cost.

--- a/src/movement_optimizer/trajectory/optimizer_diagnostics.py
+++ b/src/movement_optimizer/trajectory/optimizer_diagnostics.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2026 D-Sorganization. All rights reserved.
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 D-sorganization
 """Stall detection, solver callbacks, and single-start orchestration."""
 
 from __future__ import annotations

--- a/src/movement_optimizer/trajectory/optimizer_guess.py
+++ b/src/movement_optimizer/trajectory/optimizer_guess.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2026 D-Sorganization. All rights reserved.
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 D-sorganization
 """Initial guess generation strategies for multi-start trajectory optimisation."""
 
 from __future__ import annotations

--- a/src/movement_optimizer/trajectory/optimizer_packaging.py
+++ b/src/movement_optimizer/trajectory/optimizer_packaging.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2026 D-Sorganization. All rights reserved.
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 D-sorganization
 """Result-packaging helpers for the trajectory optimiser.
 
 These free functions handle the post-solve steps: expanding the solver's

--- a/src/movement_optimizer/trajectory/optimizer_parallel.py
+++ b/src/movement_optimizer/trajectory/optimizer_parallel.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2026 D-Sorganization. All rights reserved.
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 D-sorganization
 """Parallel multi-start driver for the trajectory optimiser.
 
 These free functions handle the concurrent execution of multiple SLSQP

--- a/src/movement_optimizer/trajectory/optimizer_progress.py
+++ b/src/movement_optimizer/trajectory/optimizer_progress.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2026 D-Sorganization. All rights reserved.
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 D-sorganization
 """Progress reporting and state tracking for the trajectory optimiser."""
 
 from __future__ import annotations

--- a/src/movement_optimizer/trajectory/optimizer_spline.py
+++ b/src/movement_optimizer/trajectory/optimizer_spline.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2026 D-Sorganization. All rights reserved.
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 D-sorganization
 """Spline construction and trajectory evaluation helpers.
 
 Separating these from :class:`TrajectoryOptimizer` gives them a single

--- a/src/movement_optimizer/trajectory/result.py
+++ b/src/movement_optimizer/trajectory/result.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2026 D-Sorganization. All rights reserved.
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 D-sorganization
 """Data structures for optimisation results."""
 
 from __future__ import annotations

--- a/src/movement_optimizer/trajectory/tuning.py
+++ b/src/movement_optimizer/trajectory/tuning.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2026 D-Sorganization. All rights reserved.
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024-2026 D-sorganization
 """Tuning parameters for the trajectory optimiser.
 
 All weights below are **tuning parameters** chosen empirically to balance


### PR DESCRIPTION
## Summary

Closes #326 — License present but no audit.

## Changes

- Replaced `# Copyright (c) 2026 D-Sorganization. All rights reserved.` with `# SPDX-License-Identifier: MIT\n# Copyright (c) 2024-2026 D-sorganization` across all 60 Python source files.
- Added explicit SPDX identifier for REUSE / FOSSA / license compliance tooling.
- Aligned copyright year range with the existing `LICENSE` file.

## Verification

- [x] `grep -r 'All rights reserved' src/` returns no matches.
- [x] `python3 -m py_compile` passes for all modified files.
- [x] No functional code changes.

## Checklist

- [x] Conventional commit format.
- [x] References the issue it closes.
- [x] No breaking changes.