### PR TITLE
fix(trajectory): add logging for CancelledError in optimizer_diagnostics

### DIFF
--- a/src/movement_optimizer/trajectory/optimizer_diagnostics.py
+++ b/src/movement_optimizer/trajectory/optimizer_diagnostics.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable
 
 from numpy.typing import NDArray
@@ -10,6 +11,8 @@ from scipy.optimize import minimize
 
 from .result import CancelledError
 from .tuning import MAX_ITER_PER_START
+
+logger = logging.getLogger(__name__)
 
 
 def make_cancel_callback(cancel_event) -> Callable[[NDArray], None]:
@@ -102,6 +105,7 @@ def run_single_start(
     try:
         res = run_minimize(wp0.flatten(), cost_fn, bounds, constraints, cancel_event)
     except CancelledError:
+        logger.info("Optimization cancelled by user")
         return None
 
     if cancel_event.is_set():


### PR DESCRIPTION
## Summary

Adds an `INFO`-level log when optimization is cancelled by user in `optimizer_diagnostics.py`, addressing the silent `try/except CancelledError: return None` that returned `None` without recording the cancellation event.

## Changes

- Added `import logging` and `logger = logging.getLogger(__name__)`
- Added `logger.info("Optimization cancelled by user")` before `return None` in the `except CancelledError` block

## Fixes

- Assessment finding D: try/except returning None without logging in optimizer_diagnostics.py

## Testing

- 440 tests pass (5 pre-existing failures in `test_bilateral_3d_renderer.py` due to local matplotlib 3D projection environment issue)
