### PR TITLE
🎨 Palette: [UX improvement] Add keyboard shortcuts to playback controls

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -21,3 +21,6 @@
 ## 2024-04-27 - Contextual Tooltips for Disabled States
 **Learning:** In PyQt6 UIs, disabling buttons during long-running tasks without explaining *why* they are disabled (or what state the system is currently in) creates user confusion. Standard tooltips describing the action often feel contradictory when the action is disabled.
 **Action:** Always dynamically update `setToolTip()` alongside `setEnabled()` state changes (e.g. on `cancel_btn` when cancellation is already in progress, or `clear_compare_btn` when there is nothing to clear).
+## 2026-04-29 - Adding Keyboard Shortcuts to PyQt6 Media Controls
+**Learning:** Common media keys (Space, Left, Right, Home) can easily be bound to QPushButton instances using `setShortcut()` and visually signaled to users by updating their tooltip to include the shortcut in parentheses.
+**Action:** Always bind these expected keyboard shortcuts and update tooltips for simple accessibility UX boosts in Qt applications.

--- a/src/movement_optimizer/gui/playback_controls.py
+++ b/src/movement_optimizer/gui/playback_controls.py
@@ -22,21 +22,25 @@ class PlaybackControls(QWidget):
         layout.setContentsMargins(4, 4, 4, 4)
 
         self.btn_rewind = QPushButton("\u23ee")
-        self.btn_rewind.setToolTip("Rewind to beginning")
+        self.btn_rewind.setToolTip("Rewind to beginning (Home)")
         self.btn_rewind.setAccessibleName("Rewind to beginning")
+        self.btn_rewind.setShortcut("Home")
 
         self.btn_back = QPushButton("\u25c0")
-        self.btn_back.setToolTip("Step backward one frame")
+        self.btn_back.setToolTip("Step backward one frame (Left)")
         self.btn_back.setAccessibleName("Step backward one frame")
+        self.btn_back.setShortcut("Left")
 
         self.btn_play = QPushButton("\u25b6 Play")
         self.btn_play.setProperty("class", "primary")
-        self.btn_play.setToolTip("Play or pause animation")
+        self.btn_play.setToolTip("Play or pause animation (Space)")
         self.btn_play.setAccessibleName("Play or pause animation")
+        self.btn_play.setShortcut("Space")
 
         self.btn_fwd = QPushButton("\u25b6")
-        self.btn_fwd.setToolTip("Step forward one frame")
+        self.btn_fwd.setToolTip("Step forward one frame (Right)")
         self.btn_fwd.setAccessibleName("Step forward one frame")
+        self.btn_fwd.setShortcut("Right")
 
         self.btn_rewind.clicked.connect(self.rewind.emit)
         self.btn_back.clicked.connect(self.step_back.emit)
@@ -78,11 +82,11 @@ class PlaybackControls(QWidget):
     def set_playing(self, playing: bool) -> None:
         if playing:
             self.btn_play.setText("\u23f8 Pause")
-            self.btn_play.setToolTip("Pause animation")
+            self.btn_play.setToolTip("Pause animation (Space)")
             self.btn_play.setAccessibleName("Pause animation")
         else:
             self.btn_play.setText("\u25b6 Play")
-            self.btn_play.setToolTip("Play animation")
+            self.btn_play.setToolTip("Play animation (Space)")
             self.btn_play.setAccessibleName("Play animation")
 
     def set_frame_position(self, current_frame: int, total_frames: int) -> None:


### PR DESCRIPTION
💡 What: Added keyboard shortcuts (`Home`, `Left`, `Space`, `Right`) to the playback transport controls (Rewind, Step Backward, Play/Pause, Step Forward) and updated their tooltips to display these shortcuts.
🎯 Why: Makes the animation playback interface more accessible and easier to control without requiring precise mouse movements, saving time and improving usability.
♿ Accessibility:
- Added `setShortcut` to corresponding buttons.
- Updated tooltips to visually communicate available shortcuts to the user.

---
*PR created automatically by Jules for task [5227419470103975174](https://jules.google.com/task/5227419470103975174) started by @dieterolson*