### PR TITLE
fix: validate export paths to prevent traversal (#398)

### DIFF
--- a/src/movement_optimizer/export.py
+++ b/src/movement_optimizer/export.py
@@ -5,6 +5,14 @@ Design Principles:
     DBC  -- preconditions checked at function entry.
     DRY  -- common save logic factored into each function.
     LoD  -- callers pass only figure + path, no internal state.
+
+Security:
+    Export paths are validated to prevent path traversal attacks. When a
+    ``base_dir`` is supplied, the resolved output path must reside inside
+    that directory; absolute paths and ``..`` components that escape the
+    base are rejected. When no ``base_dir`` is supplied (e.g. the GUI
+    passes a path picked by the user via the OS file dialog), the path is
+    still normalized and checked for embedded null bytes.
 """
 
 from __future__ import annotations
@@ -12,11 +20,56 @@ from __future__ import annotations
 import logging
 import os
 from collections.abc import Callable
+from pathlib import Path
 
 from matplotlib.animation import FuncAnimation, PillowWriter
 from matplotlib.figure import Figure
 
 logger = logging.getLogger(__name__)
+
+
+def _validate_export_path(path: str, base_dir: str | os.PathLike[str] | None) -> Path:
+    """Normalize ``path`` and validate it for safe export.
+
+    When ``base_dir`` is provided, the resolved path must be located inside
+    ``base_dir``. Otherwise only basic hygiene checks are applied (the path
+    must be a non-empty string with no embedded null bytes).
+
+    Args:
+        path: Caller-supplied output path.
+        base_dir: Optional containment directory. If given, ``path`` is
+            resolved relative to it and rejected if it escapes the base.
+
+    Returns:
+        The resolved absolute :class:`pathlib.Path` to write to.
+
+    Raises:
+        ValueError: If ``path`` is empty, contains a null byte, or escapes
+            ``base_dir`` when one is supplied.
+    """
+    if not isinstance(path, str) or not path:
+        raise ValueError("path must be a non-empty string")
+    if "\x00" in path:
+        raise ValueError("path must not contain null bytes")
+
+    candidate = Path(path)
+
+    if base_dir is None:
+        # GUI flow: user already picked the location via the OS file dialog.
+        # Normalize and return without containment enforcement.
+        return candidate.resolve(strict=False)
+
+    base = Path(base_dir).resolve(strict=False)
+    if candidate.is_absolute():
+        resolved = candidate.resolve(strict=False)
+    else:
+        resolved = (base / candidate).resolve(strict=False)
+
+    try:
+        resolved.relative_to(base)
+    except ValueError as exc:
+        raise ValueError(f"path {path!r} escapes base directory {str(base)!r}") from exc
+    return resolved
 
 
 def export_animation_gif(
@@ -25,6 +78,7 @@ def export_animation_gif(
     n_frames: int,
     path: str,
     fps: int = 15,
+    base_dir: str | os.PathLike[str] | None = None,
 ) -> None:
     """Export a matplotlib animation as a GIF file.
 
@@ -34,41 +88,62 @@ def export_animation_gif(
         n_frames: Total number of animation frames (must be > 0).
         path: Output file path (should end in ``.gif``).
         fps: Frames per second for playback (default 15).
+        base_dir: Optional directory the resolved ``path`` must be inside.
 
     Raises:
-        ValueError: If n_frames <= 0 or fps <= 0.
+        ValueError: If ``n_frames <= 0``, ``fps <= 0``, or ``path`` fails
+            validation (empty, null byte, or escapes ``base_dir``).
     """
     if n_frames <= 0:
         raise ValueError(f"n_frames must be positive, got {n_frames}")
     if fps <= 0:
         raise ValueError(f"fps must be positive, got {fps}")
-    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+    safe_path = _validate_export_path(path, base_dir)
+    safe_path.parent.mkdir(parents=True, exist_ok=True)
 
     anim = FuncAnimation(fig, draw_frame_fn, frames=n_frames, blit=False)  # type: ignore[arg-type]
     writer = PillowWriter(fps=fps)
-    anim.save(path, writer=writer)  # type: ignore[arg-type]
-    logger.info("Exported GIF animation to %s (%d frames, %d fps)", path, n_frames, fps)
+    anim.save(str(safe_path), writer=writer)  # type: ignore[arg-type]
+    logger.info("Exported GIF animation to %s (%d frames, %d fps)", safe_path, n_frames, fps)
 
 
-def export_plots_png(fig: Figure, path: str) -> None:
+def export_plots_png(
+    fig: Figure,
+    path: str,
+    base_dir: str | os.PathLike[str] | None = None,
+) -> None:
     """Export a matplotlib figure as a PNG image.
 
-    Preconditions:
-        fig is a valid matplotlib Figure.
-        path is a writable file path.
+    Args:
+        fig: Matplotlib Figure to save.
+        path: Output file path.
+        base_dir: Optional directory the resolved ``path`` must be inside.
+
+    Raises:
+        ValueError: If ``path`` fails validation.
     """
-    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
-    fig.savefig(path, format="png", dpi=150, bbox_inches="tight")
-    logger.info("Exported PNG to %s", path)
+    safe_path = _validate_export_path(path, base_dir)
+    safe_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(str(safe_path), format="png", dpi=150, bbox_inches="tight")
+    logger.info("Exported PNG to %s", safe_path)
 
 
-def export_plots_pdf(fig: Figure, path: str) -> None:
+def export_plots_pdf(
+    fig: Figure,
+    path: str,
+    base_dir: str | os.PathLike[str] | None = None,
+) -> None:
     """Export a matplotlib figure as a PDF file.
 
-    Preconditions:
-        fig is a valid matplotlib Figure.
-        path is a writable file path.
+    Args:
+        fig: Matplotlib Figure to save.
+        path: Output file path.
+        base_dir: Optional directory the resolved ``path`` must be inside.
+
+    Raises:
+        ValueError: If ``path`` fails validation.
     """
-    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
-    fig.savefig(path, format="pdf", bbox_inches="tight")
-    logger.info("Exported PDF to %s", path)
+    safe_path = _validate_export_path(path, base_dir)
+    safe_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(str(safe_path), format="pdf", bbox_inches="tight")
+    logger.info("Exported PDF to %s", safe_path)

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 
 import matplotlib
 import numpy as np
+import pytest
 from matplotlib.figure import Figure
 
 matplotlib.use("Agg")
 
 from movement_optimizer.export import (
+    _validate_export_path,
     export_animation_gif,
     export_plots_pdf,
     export_plots_png,
@@ -62,3 +64,80 @@ class TestExportGIF:
         export_animation_gif(fig, draw_frame, n_frames=5, path=str(path), fps=5)
         assert path.exists()
         assert path.stat().st_size > 0
+
+
+class TestPathTraversalValidation:
+    """Issue #398: paths must be validated to prevent traversal attacks."""
+
+    def test_rejects_empty_path(self, tmp_path):
+        with pytest.raises(ValueError, match="non-empty"):
+            _validate_export_path("", base_dir=tmp_path)
+
+    def test_rejects_null_byte(self, tmp_path):
+        with pytest.raises(ValueError, match="null"):
+            _validate_export_path("foo\x00.png", base_dir=tmp_path)
+
+    def test_rejects_dotdot_escape(self, tmp_path):
+        with pytest.raises(ValueError, match="escapes base directory"):
+            _validate_export_path("../escape.png", base_dir=tmp_path)
+
+    def test_rejects_deep_dotdot_escape(self, tmp_path):
+        with pytest.raises(ValueError, match="escapes base directory"):
+            _validate_export_path("a/b/../../../escape.png", base_dir=tmp_path)
+
+    def test_rejects_absolute_path_outside_base(self, tmp_path, tmp_path_factory):
+        outside = tmp_path_factory.mktemp("outside") / "evil.png"
+        with pytest.raises(ValueError, match="escapes base directory"):
+            _validate_export_path(str(outside), base_dir=tmp_path)
+
+    def test_accepts_path_inside_base(self, tmp_path):
+        resolved = _validate_export_path("ok.png", base_dir=tmp_path)
+        assert resolved == (tmp_path / "ok.png").resolve()
+
+    def test_accepts_nested_subdir(self, tmp_path):
+        resolved = _validate_export_path("sub/dir/ok.png", base_dir=tmp_path)
+        assert resolved == (tmp_path / "sub" / "dir" / "ok.png").resolve()
+
+    def test_accepts_absolute_path_inside_base(self, tmp_path):
+        target = tmp_path / "ok.png"
+        resolved = _validate_export_path(str(target), base_dir=tmp_path)
+        assert resolved == target.resolve()
+
+    def test_no_base_dir_still_rejects_null_byte(self):
+        with pytest.raises(ValueError, match="null"):
+            _validate_export_path("foo\x00.png", base_dir=None)
+
+    def test_no_base_dir_still_rejects_empty(self):
+        with pytest.raises(ValueError, match="non-empty"):
+            _validate_export_path("", base_dir=None)
+
+    def test_export_png_rejects_traversal(self, tmp_path):
+        fig = _make_figure()
+        with pytest.raises(ValueError, match="escapes base directory"):
+            export_plots_png(fig, "../evil.png", base_dir=str(tmp_path))
+
+    def test_export_pdf_rejects_traversal(self, tmp_path):
+        fig = _make_figure()
+        with pytest.raises(ValueError, match="escapes base directory"):
+            export_plots_pdf(fig, "../evil.pdf", base_dir=str(tmp_path))
+
+    def test_export_gif_rejects_traversal(self, tmp_path):
+        fig = _make_figure()
+
+        def draw_frame(_: int) -> None:
+            pass
+
+        with pytest.raises(ValueError, match="escapes base directory"):
+            export_animation_gif(
+                fig, draw_frame, n_frames=2, path="../evil.gif", base_dir=str(tmp_path)
+            )
+
+    def test_export_png_rejects_null_byte(self, tmp_path):
+        fig = _make_figure()
+        with pytest.raises(ValueError, match="null"):
+            export_plots_png(fig, str(tmp_path / "ev\x00il.png"))
+
+    def test_export_png_writes_inside_base(self, tmp_path):
+        fig = _make_figure()
+        export_plots_png(fig, "ok.png", base_dir=str(tmp_path))
+        assert (tmp_path / "ok.png").exists()


### PR DESCRIPTION
## Summary
- Adds `_validate_export_path` to `export.py` and applies it to all three export functions (GIF, PNG, PDF).
- When an optional `base_dir` is supplied the resolved output must remain inside it; absolute paths and `..` components that escape the base are rejected.
- Even without a `base_dir` (GUI flow where the user picks the path via the OS file dialog), empty strings and embedded null bytes are rejected and the path is normalized via `pathlib.Path.resolve()`.
- Backward-compatible: existing GUI callers in `gui/file_operations.py` continue to work unchanged.

## Test plan
- [x] 15 new unit tests in `tests/test_export.py` cover: empty path, null byte, single and deep `..` escape, absolute path outside base, absolute path inside base, nested subdirs, end-to-end PNG/PDF/GIF traversal rejection, write-inside-base success.
- [x] `pytest tests/test_export.py` -- 19/19 pass.
- [x] Full test suite (excluding pre-existing local Qt DLL failures unrelated to this change) -- 415 pass, 3 skipped.
- [x] `ruff check` and `ruff format` clean.

Fixes #398

🤖 Generated with [Claude Code](https://claude.com/claude-code)