### PR TITLE
test: add edge case coverage for trajectory optimizer (#412)

### DIFF
--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1,0 +1,340 @@
+# Copyright (c) 2026 D-Sorganization. All rights reserved.
+"""Edge-case coverage for the trajectory optimizer (issue #412).
+
+These tests probe degenerate / boundary inputs that are not exercised by
+``test_trajectory_optimization.py``.  The goal is to assert the public
+contract: the optimizer either returns a finite, contract-conforming
+:class:`OptimizationResult` or raises a precise, documented exception --
+never NaN/inf in arrays and never an obscure stack trace.
+
+Per ``CLAUDE.md`` the SLSQP solver is sensitive to platform-specific
+floating-point behaviour, so tolerances are deliberately loose and
+assertions focus on shape / finiteness / hard-constraint satisfaction
+rather than exact cost values.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from movement_optimizer.models import BodyModel, make_squat_config
+from movement_optimizer.trajectory import OptimizationResult, TrajectoryOptimizer
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Loose tolerance applied when checking the inner-BOS hard constraint.
+# Matches the slack used by ``test_com_stays_in_inner_bos``.
+_BOS_TOL_M = 0.01
+
+
+def _build_squat_optimizer(
+    body: BodyModel,
+    bar_mass: float,
+    *,
+    duration: float = 2.0,
+    n_waypoints: int = 6,
+    n_eval: int = 20,
+    n_starts: int = 1,
+    smoothness: float = 1.0,
+    q_start_override: np.ndarray | None = None,
+    q_end_override: np.ndarray | None = None,
+) -> TrajectoryOptimizer:
+    """Build a small squat optimizer with overridable knobs."""
+    dyn, qs, qe, qb = make_squat_config(body, bar_mass)
+    if q_start_override is not None:
+        qs = q_start_override
+    if q_end_override is not None:
+        qe = q_end_override
+    return TrajectoryOptimizer(
+        body,
+        dyn,
+        "squat",
+        bar_mass,
+        qs,
+        qe,
+        qb,
+        duration=duration,
+        n_waypoints=n_waypoints,
+        n_eval=n_eval,
+        n_starts=n_starts,
+        smoothness=smoothness,
+    )
+
+
+def _assert_result_finite(result: OptimizationResult, n_eval: int) -> None:
+    """All public arrays must be the right shape and free of NaN / inf."""
+    assert isinstance(result, OptimizationResult)
+    assert result.t.shape == (n_eval,)
+    assert result.q.shape == (n_eval, 3)
+    assert result.qd.shape == (n_eval, 3)
+    assert result.qdd.shape == (n_eval, 3)
+    assert result.torques.shape == (n_eval, 3)
+    assert result.power.shape == (n_eval, 3)
+    assert result.com.shape == (n_eval, 2)
+    assert result.bar.shape == (n_eval, 2)
+    for name, arr in (
+        ("t", result.t),
+        ("q", result.q),
+        ("qd", result.qd),
+        ("qdd", result.qdd),
+        ("torques", result.torques),
+        ("power", result.power),
+        ("com", result.com),
+        ("bar", result.bar),
+    ):
+        assert np.all(np.isfinite(arr)), f"{name} contains non-finite values"
+    assert np.isfinite(result.cost), "result.cost must be finite"
+
+
+def _assert_inner_bos(result: OptimizationResult, body: BodyModel) -> None:
+    """COM must respect the inner-BOS hard constraint (with loose slack)."""
+    com_x = result.com[:, 0]
+    assert np.all(com_x >= body.inner_heel - _BOS_TOL_M), (
+        f"COM below inner_heel: min={com_x.min():.4f}, bound={body.inner_heel:.4f}"
+    )
+    assert np.all(com_x <= body.inner_toe + _BOS_TOL_M), (
+        f"COM above inner_toe: max={com_x.max():.4f}, bound={body.inner_toe:.4f}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Duration edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestDurationEdgeCases:
+    def test_very_short_duration_does_not_crash(self) -> None:
+        """A 50 ms movement is physically extreme but must not crash.
+
+        SLSQP may report ``success=False`` when the dynamics torques explode,
+        but it MUST return a result with finite arrays (no NaN/inf).
+        """
+        body = BodyModel(75.0, 1.75)
+        opt = _build_squat_optimizer(body, 60.0, duration=0.05)
+        try:
+            result = opt.optimize()
+        except ValueError:
+            # A clear ValueError is also an acceptable contract.
+            return
+        _assert_result_finite(result, opt.n_eval)
+        # cost may be huge; just ensure it's a real number
+        assert result.cost >= 0.0 or not result.success
+
+    def test_very_long_duration_completes_quickly(self) -> None:
+        """A 30 s movement should solve cheaply (no OOM, no blow-up)."""
+        body = BodyModel(75.0, 1.75)
+        opt = _build_squat_optimizer(body, 60.0, duration=30.0)
+        result = opt.optimize()
+        _assert_result_finite(result, opt.n_eval)
+        # Long-duration solutions should easily satisfy balance.
+        _assert_inner_bos(result, body)
+
+    def test_duration_one_second(self) -> None:
+        """A typical 1-second lift is the happy-path baseline for this group."""
+        body = BodyModel(75.0, 1.75)
+        opt = _build_squat_optimizer(body, 60.0, duration=1.0)
+        result = opt.optimize()
+        _assert_result_finite(result, opt.n_eval)
+
+
+# ---------------------------------------------------------------------------
+# Barbell mass edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestBarbellMassEdgeCases:
+    def test_zero_bar_mass_converges(self) -> None:
+        """Body-only trajectory (no external load) should converge cleanly."""
+        body = BodyModel(75.0, 1.75)
+        opt = _build_squat_optimizer(body, 0.0, n_waypoints=8, n_eval=25)
+        result = opt.optimize()
+        _assert_result_finite(result, opt.n_eval)
+        assert result.success, "Body-only squat should converge"
+        _assert_inner_bos(result, body)
+
+    def test_near_zero_bar_mass(self) -> None:
+        """An almost-empty bar should behave like the zero-mass case."""
+        body = BodyModel(75.0, 1.75)
+        opt = _build_squat_optimizer(body, 1e-3, n_waypoints=8, n_eval=25)
+        result = opt.optimize()
+        _assert_result_finite(result, opt.n_eval)
+        assert result.success, "Near-zero bar mass should converge"
+
+    def test_extremely_heavy_bar(self) -> None:
+        """A 500 kg bar may not converge but must yield a finite, readable result."""
+        body = BodyModel(75.0, 1.75)
+        opt = _build_squat_optimizer(body, 500.0)
+        result = opt.optimize()
+        _assert_result_finite(result, opt.n_eval)
+        # 500 kg is well beyond physiological capacity; success is not required,
+        # but the result MUST be well-formed (no NaN/inf already checked above).
+
+
+# ---------------------------------------------------------------------------
+# Extreme body proportions
+# ---------------------------------------------------------------------------
+
+
+class TestExtremeBodyProportions:
+    def test_very_tall_body(self) -> None:
+        """A 2.2 m lifter is near the human upper bound; optimizer must cope."""
+        body = BodyModel(95.0, 2.2)
+        opt = _build_squat_optimizer(body, 60.0, n_waypoints=8, n_eval=25)
+        result = opt.optimize()
+        _assert_result_finite(result, opt.n_eval)
+        assert result.success, "Tall body squat should converge"
+        _assert_inner_bos(result, body)
+
+    def test_very_short_body(self) -> None:
+        """A 1.4 m lifter is near the human lower bound; optimizer must cope."""
+        body = BodyModel(50.0, 1.4)
+        opt = _build_squat_optimizer(body, 30.0, n_waypoints=8, n_eval=25)
+        result = opt.optimize()
+        _assert_result_finite(result, opt.n_eval)
+        assert result.success, "Short body squat should converge"
+        _assert_inner_bos(result, body)
+
+    def test_segment_multiplier_extremes(self) -> None:
+        """Segments at the validated multiplier extremes must still produce a usable plan."""
+        body = BodyModel(
+            75.0,
+            1.75,
+            seg_multipliers={"lower_leg": 0.5, "upper_leg": 2.0, "torso": 1.5},
+        )
+        opt = _build_squat_optimizer(body, 40.0, n_waypoints=8, n_eval=25)
+        result = opt.optimize()
+        _assert_result_finite(result, opt.n_eval)
+
+
+# ---------------------------------------------------------------------------
+# Zero range-of-motion (start == end)
+# ---------------------------------------------------------------------------
+
+
+class TestZeroRangeOfMotion:
+    def test_identical_start_and_end_angles(self) -> None:
+        """When start == end, the trajectory should be approximately constant.
+
+        The optimizer must not raise; it should return a feasible result with
+        very small joint travel.  We allow a small tolerance because cubic
+        splines can ring slightly around the endpoints.
+        """
+        body = BodyModel(75.0, 1.75)
+        dyn, qs, _qe, qb = make_squat_config(body, 60.0)
+        opt = TrajectoryOptimizer(
+            body,
+            dyn,
+            "squat",
+            60.0,
+            qs,
+            qs.copy(),
+            qb,
+            duration=2.0,
+            n_waypoints=6,
+            n_eval=20,
+            n_starts=1,
+        )
+        result = opt.optimize()
+        _assert_result_finite(result, opt.n_eval)
+        # Each joint should travel less than ~3 degrees from the constant pose.
+        max_travel_rad = float(np.max(np.abs(result.q - qs)))
+        assert max_travel_rad < np.radians(5.0), (
+            f"Zero-ROM trajectory drifted {np.degrees(max_travel_rad):.2f} deg"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Multistart count
+# ---------------------------------------------------------------------------
+
+
+class TestMultistartCount:
+    def test_single_start(self) -> None:
+        """n_starts=1 takes the single-start code path and must succeed."""
+        body = BodyModel(75.0, 1.75)
+        opt = _build_squat_optimizer(body, 60.0, n_starts=1)
+        result = opt.optimize()
+        _assert_result_finite(result, opt.n_eval)
+        assert result.success
+
+    def test_many_multistarts(self) -> None:
+        """A larger n_starts exercises the parallel path and must succeed."""
+        body = BodyModel(75.0, 1.75)
+        opt = _build_squat_optimizer(body, 60.0, n_starts=4)
+        result = opt.optimize()
+        _assert_result_finite(result, opt.n_eval)
+        assert result.success
+        _assert_inner_bos(result, body)
+
+    def test_single_vs_many_starts_both_valid(self) -> None:
+        """Both single- and multi-start paths must yield finite, valid results.
+
+        We don't assert that multi-start is *better* (SLSQP can converge to
+        the same basin from any reasonable seed); we only assert that both
+        paths produce contract-conforming output.
+        """
+        body = BodyModel(75.0, 1.75)
+        opt1 = _build_squat_optimizer(body, 60.0, n_starts=1)
+        opt_n = _build_squat_optimizer(body, 60.0, n_starts=3)
+        r1 = opt1.optimize()
+        rn = opt_n.optimize()
+        _assert_result_finite(r1, opt1.n_eval)
+        _assert_result_finite(rn, opt_n.n_eval)
+
+
+# ---------------------------------------------------------------------------
+# Smoothness boundary values
+# ---------------------------------------------------------------------------
+
+
+class TestSmoothnessBoundary:
+    def test_smoothness_zero(self) -> None:
+        """smoothness=0 disables jerk / torque-rate / endpoint regularisation."""
+        body = BodyModel(75.0, 1.75)
+        opt = _build_squat_optimizer(body, 60.0, smoothness=0.0)
+        # All smoothness-scaled weights should collapse to zero.
+        assert opt.jerk_weight == 0.0
+        assert opt.torque_rate_weight == 0.0
+        assert opt.endpoint_weight == 0.0
+        result = opt.optimize()
+        _assert_result_finite(result, opt.n_eval)
+
+    def test_smoothness_high(self) -> None:
+        """High smoothness must not break the solver or produce NaNs."""
+        body = BodyModel(75.0, 1.75)
+        opt = _build_squat_optimizer(body, 60.0, smoothness=10.0)
+        # Smoothness scales all three regularisation weights linearly.
+        assert opt.jerk_weight > 0.0
+        assert opt.torque_rate_weight > 0.0
+        assert opt.endpoint_weight > 0.0
+        result = opt.optimize()
+        _assert_result_finite(result, opt.n_eval)
+
+
+# ---------------------------------------------------------------------------
+# Constructor preconditions (DBC contract)
+# ---------------------------------------------------------------------------
+
+
+class TestConstructorPreconditions:
+    def test_too_few_waypoints_raises(self) -> None:
+        """The optimizer requires >= 4 waypoints; fewer must raise ValueError."""
+        body = BodyModel(75.0, 1.75)
+        dyn, qs, qe, qb = make_squat_config(body, 60.0)
+        with pytest.raises(ValueError, match=r">= 4 waypoints"):
+            TrajectoryOptimizer(
+                body, dyn, "squat", 60.0, qs, qe, qb, n_waypoints=3, n_eval=20, n_starts=1
+            )
+
+    def test_minimum_waypoints_accepted(self) -> None:
+        """The minimum legal waypoint count (4) must construct and optimize."""
+        body = BodyModel(75.0, 1.75)
+        dyn, qs, qe, qb = make_squat_config(body, 60.0)
+        opt = TrajectoryOptimizer(
+            body, dyn, "squat", 60.0, qs, qe, qb, n_waypoints=4, n_eval=20, n_starts=1
+        )
+        result = opt.optimize()
+        _assert_result_finite(result, opt.n_eval)


### PR DESCRIPTION
## Summary

Adds `tests/test_edge_cases.py` with 17 new tests probing boundary / degenerate inputs to `TrajectoryOptimizer.optimize()` that were not exercised by the existing happy-path suite.

Each test asserts the public contract: the result has correctly-shaped, finite arrays (no NaN/inf), satisfies the inner-BOS hard constraint where applicable, and either reports `success` or raises a precise, documented exception. Tolerances are intentionally loose per `CLAUDE.md` because SLSQP results vary slightly across platforms.

## Edge cases covered

- **Duration**
  - Very short (`0.05 s`) — must not crash; either succeeds or raises a clear `ValueError`.
  - Very long (`30 s`) — must not OOM or blow up.
  - `1 s` baseline as a sanity check.
- **Barbell mass**
  - Zero mass — body-only trajectory must converge.
  - Near-zero mass (`1e-3 kg`) — same as zero case.
  - Extremely heavy (`500 kg`) — result must be finite even when infeasible.
- **Extreme body proportions**
  - Very tall (`height = 2.2 m`).
  - Very short (`height = 1.4 m`).
  - Segment-length multipliers at the validated extremes.
- **Zero range-of-motion** — `q_start == q_end`; trajectory must stay within ~5° of the constant pose.
- **Multistart count** — `n_starts=1` (single-path) and `n_starts=4` (parallel-path), plus a side-by-side comparison both yield contract-conforming output.
- **Smoothness boundary** — `smoothness=0` collapses jerk / torque-rate / endpoint weights to zero, `smoothness=10` exercises the high end without producing NaNs.
- **Constructor preconditions** — `n_waypoints<4` raises `ValueError(match=">= 4 waypoints")`; `n_waypoints=4` is the legal minimum and constructs/optimizes successfully.

## Test plan

- [x] `PYTHONPATH=src QT_QPA_PLATFORM=offscreen python3 -m pytest tests/ -q` — 549 passed (532 baseline + 17 new), 1 pre-existing warning, ~14.5 s on the agent host.
- [x] `ruff check tests/test_edge_cases.py` — clean.
- [x] `ruff format --check tests/test_edge_cases.py` — already formatted.
- [x] New file alone runs in ~1.2 s — well within the 10 s per-test budget; no `slow` marker required.

No production code was modified. Closes #412.

https://claude.ai/code/session_01Vw3sFVXpaJrPRXrseq9dAL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vw3sFVXpaJrPRXrseq9dAL)_