### PR TITLE
feat: validate session/config schemas (#403)

### DIFF
--- a/src/movement_optimizer/gui/file_operations.py
+++ b/src/movement_optimizer/gui/file_operations.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING, Any
 from PyQt6.QtWidgets import QFileDialog, QMessageBox
 
 from ..export import export_animation_gif, export_plots_pdf, export_plots_png
-from ..persistence import load_solution, save_solution
+from ..persistence import InvalidStateFileError, load_solution, save_solution
 from ..trajectory import OptimizationResult
 
 if TYPE_CHECKING:
@@ -91,6 +91,8 @@ class FileOperationsMixin:
                 f"Bar mass: {data.get('bar_mass')} kg\n"
                 f"Cost: {data.get('metadata', {}).get('cost', 'N/A')}",
             )
+        except InvalidStateFileError as e:
+            QMessageBox.critical(self, "Invalid Solution File", str(e))
         except (OSError, json.JSONDecodeError, KeyError, ValueError) as e:
             QMessageBox.critical(self, "Load Error", str(e))
 

--- a/src/movement_optimizer/gui/main_window.py
+++ b/src/movement_optimizer/gui/main_window.py
@@ -30,7 +30,7 @@ from PyQt6.QtWidgets import (
 
 from ..comparison import ComparisonStore
 from ..models import BodyModel
-from ..persistence import load_app_state, save_app_state
+from ..persistence import InvalidStateFileError, load_app_state, save_app_state
 from ..trajectory import (
     OptimizationResult,
     SolutionCache,
@@ -179,7 +179,16 @@ class MainWindow(
 
     def try_restore_session(self) -> None:
         """Check for a saved session and offer to restore it."""
-        state = load_app_state()
+        try:
+            state = load_app_state()
+        except InvalidStateFileError as exc:
+            logger.warning("Saved session failed schema validation: %s", exc)
+            QMessageBox.warning(
+                self,
+                "Session State Invalid",
+                f"Saved session could not be restored:\n{exc}",
+            )
+            return
         if state is None:
             return
         reply = QMessageBox.question(

--- a/src/movement_optimizer/persistence.py
+++ b/src/movement_optimizer/persistence.py
@@ -8,6 +8,13 @@ Design Principles:
     DBC  -- preconditions checked at function entry.
     DRY  -- array conversion logic is factored into helpers.
     LoD  -- callers pass only the data they want persisted.
+
+Schema validation:
+    All persisted JSON files include a ``schema_version`` field. Loading
+    a file with a missing/unknown version, missing required keys, wrong
+    value types, or out-of-range numeric values raises
+    :class:`InvalidStateFileError` (a ``ValueError`` subclass) with a
+    message that names the offending field. Issue #403.
 """
 
 from __future__ import annotations
@@ -21,8 +28,36 @@ import numpy as np
 
 from .config import load_app_paths
 from .trajectory import OptimizationResult
+from .validation import (
+    BAR_MASS_RANGE,
+    BODY_MASS_RANGE,
+    DURATION_RANGE,
+    HEIGHT_RANGE,
+    SMOOTHNESS_RANGE,
+)
 
 logger = logging.getLogger(__name__)
+
+# Schema version persisted on every save. Bump when the on-disk layout
+# changes incompatibly. Loaders reject other versions until a migration
+# is implemented.
+SCHEMA_VERSION = 1
+
+# Known exercise identifiers accepted by ``save_solution``. Keep in sync
+# with ``MainWindow.EXERCISE_CONFIGS`` and the exercise factories.
+_KNOWN_EXERCISE_TYPES = frozenset(
+    {
+        "squat",
+        "full_squat",
+        "deadlift",
+        "bench_press",
+        "clean",
+        "jerk",
+        "snatch",
+        "gait",
+        "sit_to_stand",
+    }
+)
 
 # Array field names in OptimizationResult
 _ARRAY_FIELDS = ("t", "q", "qd", "qdd", "torques", "power", "com", "bar")
@@ -35,6 +70,194 @@ _METADATA_FIELDS = (
     "elapsed_s",
     "n_evals",
 )
+
+# Slider keys persisted by ``collect_slider_values`` and the validator
+# that constrains each. Mass/height/etc. reuse the bounds in
+# ``validation.py`` so the GUI and disk format stay in lockstep.
+_SLIDER_RANGES: dict[str, tuple[float, float]] = {
+    "body_mass": BODY_MASS_RANGE,
+    "height": HEIGHT_RANGE,
+    "lower_leg": (0.5, 1.5),  # segment-length multiplier
+    "upper_leg": (0.5, 1.5),
+    "torso": (0.5, 1.5),
+    "bar_mass": BAR_MASS_RANGE,
+    "duration": DURATION_RANGE,
+    "smoothness": SMOOTHNESS_RANGE,
+}
+
+
+class InvalidStateFileError(ValueError):
+    """Raised when a persisted JSON file fails schema validation.
+
+    Subclasses :class:`ValueError` so existing callers that already
+    catch ``ValueError`` (e.g. the GUI load path) keep working without
+    code changes.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Schema validation helpers
+# ---------------------------------------------------------------------------
+
+
+def _require_mapping(data: Any, context: str) -> dict[str, Any]:
+    """Return ``data`` as a dict or raise with a descriptive context."""
+    if not isinstance(data, dict):
+        raise InvalidStateFileError(f"{context}: expected JSON object, got {type(data).__name__}")
+    return data
+
+
+def _require_key(data: dict[str, Any], key: str, context: str) -> Any:
+    if key not in data:
+        raise InvalidStateFileError(f"{context}: missing required key '{key}'")
+    return data[key]
+
+
+def _require_type(value: Any, expected: type | tuple[type, ...], field: str) -> None:
+    # ``bool`` is a subclass of ``int`` in Python; reject it explicitly when
+    # a numeric value is expected so True/False can't sneak in as 1/0.
+    if isinstance(expected, tuple):
+        numeric_expected = any(t in (int, float) for t in expected)
+    else:
+        numeric_expected = expected in (int, float)
+    if numeric_expected and isinstance(value, bool):
+        raise InvalidStateFileError(f"field '{field}': expected number, got bool")
+    if not isinstance(value, expected):
+        names = (
+            expected.__name__
+            if isinstance(expected, type)
+            else "/".join(t.__name__ for t in expected)
+        )
+        raise InvalidStateFileError(
+            f"field '{field}': expected {names}, got {type(value).__name__}"
+        )
+
+
+def _require_range(value: float, bounds: tuple[float, float], field: str) -> None:
+    low, high = bounds
+    if not (low <= value <= high):
+        raise InvalidStateFileError(f"field '{field}': value {value} out of range [{low}, {high}]")
+
+
+def _validate_schema_version(data: dict[str, Any], context: str) -> None:
+    """Reject files with a missing or unsupported schema version."""
+    if "schema_version" not in data:
+        raise InvalidStateFileError(
+            f"{context}: missing 'schema_version' (file predates schema "
+            f"validation; expected version {SCHEMA_VERSION})"
+        )
+    version = data["schema_version"]
+    if not isinstance(version, int) or isinstance(version, bool):
+        raise InvalidStateFileError(
+            f"{context}: 'schema_version' must be int, got {type(version).__name__}"
+        )
+    if version != SCHEMA_VERSION:
+        raise InvalidStateFileError(
+            f"{context}: unsupported schema_version {version} "
+            f"(expected {SCHEMA_VERSION}); no migration is available"
+        )
+
+
+def _validate_arrays_block(arrays: Any, context: str) -> None:
+    arrays_dict = _require_mapping(arrays, f"{context}: 'arrays'")
+    for key in _ARRAY_FIELDS:
+        if key not in arrays_dict:
+            raise InvalidStateFileError(f"{context}: missing required array '{key}'")
+        value = arrays_dict[key]
+        if not isinstance(value, list):
+            raise InvalidStateFileError(
+                f"{context}: 'arrays.{key}' must be a list, got {type(value).__name__}"
+            )
+
+
+def _validate_metadata_block(metadata: Any, context: str) -> None:
+    meta_dict = _require_mapping(metadata, f"{context}: 'metadata'")
+    required_types: dict[str, type | tuple[type, ...]] = {
+        "success": bool,
+        "cost": (int, float),
+        "com_horizontal_range_cm": (int, float),
+    }
+    for key, expected in required_types.items():
+        if key not in meta_dict:
+            raise InvalidStateFileError(f"{context}: missing required metadata key '{key}'")
+        # ``success`` is bool and must be checked separately to avoid the
+        # numeric-bool guard in ``_require_type``.
+        if expected is bool:
+            if not isinstance(meta_dict[key], bool):
+                raise InvalidStateFileError(
+                    f"field 'metadata.{key}': expected bool, got {type(meta_dict[key]).__name__}"
+                )
+        else:
+            _require_type(meta_dict[key], expected, f"metadata.{key}")
+    # Optional numeric fields with defaults.
+    for opt_key in ("elapsed_s", "n_evals", "n_joint_limit_violations"):
+        if opt_key in meta_dict:
+            _require_type(meta_dict[opt_key], (int, float), f"metadata.{opt_key}")
+
+
+def _validate_solution_schema(data: dict[str, Any]) -> None:
+    """Validate the on-disk shape of a saved solution file."""
+    context = "solution file"
+    _validate_schema_version(data, context)
+
+    exercise_type = _require_key(data, "exercise_type", context)
+    _require_type(exercise_type, str, "exercise_type")
+    if exercise_type not in _KNOWN_EXERCISE_TYPES:
+        raise InvalidStateFileError(
+            f"field 'exercise_type': unknown value '{exercise_type}' "
+            f"(known: {sorted(_KNOWN_EXERCISE_TYPES)})"
+        )
+
+    bar_mass = _require_key(data, "bar_mass", context)
+    _require_type(bar_mass, (int, float), "bar_mass")
+    _require_range(float(bar_mass), BAR_MASS_RANGE, "bar_mass")
+
+    body_params = _require_key(data, "body_params", context)
+    _require_type(body_params, dict, "body_params")
+
+    arrays = _require_key(data, "arrays", context)
+    _validate_arrays_block(arrays, context)
+    metadata = _require_key(data, "metadata", context)
+    _validate_metadata_block(metadata, context)
+
+
+def _validate_app_state_schema(data: dict[str, Any]) -> None:
+    """Validate the on-disk shape of a saved app-state file."""
+    context = "app state file"
+    _validate_schema_version(data, context)
+
+    slider_values = _require_key(data, "slider_values", context)
+    _require_type(slider_values, dict, "slider_values")
+    for key, value in slider_values.items():
+        if not isinstance(key, str):
+            raise InvalidStateFileError(
+                f"slider_values: keys must be strings, got {type(key).__name__}"
+            )
+        _require_type(value, (int, float), f"slider_values.{key}")
+        if key in _SLIDER_RANGES:
+            _require_range(float(value), _SLIDER_RANGES[key], f"slider_values.{key}")
+
+    results = _require_key(data, "results", context)
+    _require_type(results, dict, "results")
+    for etype, payload in results.items():
+        if not isinstance(etype, str):
+            raise InvalidStateFileError(
+                f"results: exercise keys must be strings, got {type(etype).__name__}"
+            )
+        if etype not in _KNOWN_EXERCISE_TYPES:
+            raise InvalidStateFileError(
+                f"results: unknown exercise type '{etype}' (known: {sorted(_KNOWN_EXERCISE_TYPES)})"
+            )
+        sub = _require_mapping(payload, f"results.{etype}")
+        if "arrays" not in sub or "metadata" not in sub:
+            raise InvalidStateFileError(f"results.{etype}: must contain 'arrays' and 'metadata'")
+        _validate_arrays_block(sub["arrays"], f"results.{etype}")
+        _validate_metadata_block(sub["metadata"], f"results.{etype}")
+
+
+# ---------------------------------------------------------------------------
+# Result <-> dict helpers
+# ---------------------------------------------------------------------------
 
 
 def _result_to_dict(result: OptimizationResult) -> dict[str, Any]:
@@ -66,6 +289,11 @@ def _dict_to_result(d: dict[str, Any]) -> OptimizationResult:
     )
 
 
+# ---------------------------------------------------------------------------
+# Public save/load API
+# ---------------------------------------------------------------------------
+
+
 def save_solution(
     path: str | Path,
     result: OptimizationResult,
@@ -80,6 +308,7 @@ def save_solution(
         result is a valid OptimizationResult.
     """
     data = {
+        "schema_version": SCHEMA_VERSION,
         "exercise_type": exercise_type,
         "bar_mass": bar_mass,
         "body_params": body_params,
@@ -94,17 +323,23 @@ def save_solution(
 def load_solution(path: str | Path) -> dict[str, Any]:
     """Load an optimization solution from a JSON file.
 
-    Returns a dict with keys: exercise_type, bar_mass, body_params,
-    arrays (dict of list data), metadata (dict of scalars).
+    Returns a dict with keys: schema_version, exercise_type, bar_mass,
+    body_params, arrays (dict of list data), metadata (dict of scalars).
 
     Raises:
         FileNotFoundError: if path does not exist.
         json.JSONDecodeError: if file is not valid JSON.
+        InvalidStateFileError: if the file fails schema validation.
     """
     input_path = Path(path)
     if not input_path.exists():
         raise FileNotFoundError(f"Solution file not found: {input_path}")
     data = json.loads(input_path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise InvalidStateFileError(
+            f"solution file: expected JSON object at top level, got {type(data).__name__}"
+        )
+    _validate_solution_schema(data)
     logger.info("Loaded solution from %s", input_path)
     return data
 
@@ -132,6 +367,7 @@ def save_app_state(
             serialized_results[etype] = _result_to_dict(result)
 
     data = {
+        "schema_version": SCHEMA_VERSION,
         "slider_values": slider_values,
         "results": serialized_results,
     }
@@ -142,7 +378,11 @@ def save_app_state(
 def load_app_state(*, state_dir: str | Path | None = None) -> dict[str, Any] | None:
     """Load the last app state from the state directory.
 
-    Returns None if no state file exists or if it is corrupt.
+    Returns None if no state file exists or if the file is not valid
+    JSON (corruption that predates schema validation). Raises
+    :class:`InvalidStateFileError` when the file parses but fails
+    schema validation -- the GUI surfaces this so the user knows their
+    state is incompatible rather than being silently discarded.
     """
     state_path = (
         load_app_paths().state_file if state_dir is None else Path(state_dir) / "last_state.json"
@@ -152,9 +392,21 @@ def load_app_state(*, state_dir: str | Path | None = None) -> dict[str, Any] | N
         return None
 
     try:
-        data = json.loads(state_path.read_text(encoding="utf-8"))
-        logger.info("Loaded app state from %s", state_path)
-        return data
-    except (json.JSONDecodeError, KeyError, OSError) as exc:
-        logger.warning("Failed to load app state: %s", exc)
+        raw = state_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        logger.warning("Failed to read app state file %s: %s", state_path, exc)
         return None
+
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        logger.warning("App state file %s is not valid JSON: %s", state_path, exc)
+        return None
+
+    if not isinstance(data, dict):
+        raise InvalidStateFileError(
+            f"app state file: expected JSON object at top level, got {type(data).__name__}"
+        )
+    _validate_app_state_schema(data)
+    logger.info("Loaded app state from %s", state_path)
+    return data

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -12,6 +12,8 @@ from conftest import make_test_result
 
 from movement_optimizer.config import load_app_paths
 from movement_optimizer.persistence import (
+    SCHEMA_VERSION,
+    InvalidStateFileError,
     load_app_state,
     load_solution,
     save_app_state,
@@ -115,3 +117,210 @@ class TestAppState:
         assert loaded is not None
         assert load_app_paths().state_file == override_dir / "last_state.json"
         assert Path(load_app_paths().state_file).exists()
+
+
+def _make_valid_app_state_payload() -> dict:
+    """Return a minimal but schema-valid app-state JSON payload."""
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "slider_values": {
+            "body_mass": 80.0,
+            "height": 1.80,
+            "lower_leg": 1.0,
+            "upper_leg": 1.0,
+            "torso": 1.0,
+            "bar_mass": 60.0,
+            "duration": 2.0,
+            "smoothness": 1.0,
+        },
+        "results": {},
+    }
+
+
+def _write_state(tmp_path, payload) -> Path:
+    state_dir = tmp_path / ".movement_optimizer"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    (state_dir / "last_state.json").write_text(json.dumps(payload), encoding="utf-8")
+    return state_dir
+
+
+class TestSchemaValidationAppState:
+    """Issue #403: explicit schema validation on app-state load."""
+
+    def test_round_trip_includes_schema_version(self, tmp_path):
+        state_dir = tmp_path / ".movement_optimizer"
+        save_app_state({}, {"body_mass": 80.0}, state_dir=str(state_dir))
+
+        raw = (state_dir / "last_state.json").read_text(encoding="utf-8")
+        payload = json.loads(raw)
+        assert payload["schema_version"] == SCHEMA_VERSION
+
+        loaded = load_app_state(state_dir=str(state_dir))
+        assert loaded is not None
+        assert loaded["schema_version"] == SCHEMA_VERSION
+
+    def test_missing_schema_version_raises(self, tmp_path):
+        payload = _make_valid_app_state_payload()
+        del payload["schema_version"]
+        state_dir = _write_state(tmp_path, payload)
+        with pytest.raises(InvalidStateFileError, match="schema_version"):
+            load_app_state(state_dir=str(state_dir))
+
+    def test_unknown_schema_version_raises(self, tmp_path):
+        payload = _make_valid_app_state_payload()
+        payload["schema_version"] = SCHEMA_VERSION + 99
+        state_dir = _write_state(tmp_path, payload)
+        with pytest.raises(InvalidStateFileError, match="unsupported schema_version"):
+            load_app_state(state_dir=str(state_dir))
+
+    def test_missing_required_key_raises(self, tmp_path):
+        payload = _make_valid_app_state_payload()
+        del payload["slider_values"]
+        state_dir = _write_state(tmp_path, payload)
+        with pytest.raises(InvalidStateFileError, match="slider_values"):
+            load_app_state(state_dir=str(state_dir))
+
+    def test_wrong_type_for_slider_values_raises(self, tmp_path):
+        payload = _make_valid_app_state_payload()
+        payload["slider_values"] = "not a dict"
+        state_dir = _write_state(tmp_path, payload)
+        with pytest.raises(InvalidStateFileError, match="slider_values"):
+            load_app_state(state_dir=str(state_dir))
+
+    def test_wrong_type_for_individual_slider_raises(self, tmp_path):
+        payload = _make_valid_app_state_payload()
+        payload["slider_values"]["body_mass"] = "heavy"
+        state_dir = _write_state(tmp_path, payload)
+        with pytest.raises(InvalidStateFileError, match=r"slider_values\.body_mass"):
+            load_app_state(state_dir=str(state_dir))
+
+    def test_out_of_range_slider_value_raises(self, tmp_path):
+        payload = _make_valid_app_state_payload()
+        payload["slider_values"]["body_mass"] = 5000.0  # absurd
+        state_dir = _write_state(tmp_path, payload)
+        with pytest.raises(InvalidStateFileError, match="out of range"):
+            load_app_state(state_dir=str(state_dir))
+
+    def test_unknown_exercise_in_results_raises(self, tmp_path):
+        payload = _make_valid_app_state_payload()
+        payload["results"]["not_a_real_exercise"] = {
+            "arrays": {},
+            "metadata": {},
+        }
+        state_dir = _write_state(tmp_path, payload)
+        with pytest.raises(InvalidStateFileError, match="not_a_real_exercise"):
+            load_app_state(state_dir=str(state_dir))
+
+    def test_top_level_not_object_raises(self, tmp_path):
+        state_dir = tmp_path / ".movement_optimizer"
+        state_dir.mkdir(parents=True)
+        (state_dir / "last_state.json").write_text("[1, 2, 3]", encoding="utf-8")
+        with pytest.raises(InvalidStateFileError, match="JSON object"):
+            load_app_state(state_dir=str(state_dir))
+
+    def test_results_block_missing_arrays_raises(self, tmp_path):
+        payload = _make_valid_app_state_payload()
+        payload["results"]["squat"] = {"metadata": {}}
+        state_dir = _write_state(tmp_path, payload)
+        with pytest.raises(InvalidStateFileError, match="arrays"):
+            load_app_state(state_dir=str(state_dir))
+
+
+class TestSchemaValidationSolution:
+    """Issue #403: explicit schema validation on solution load."""
+
+    def _valid_solution_payload(self) -> dict:
+        result = make_test_result()
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "exercise_type": "squat",
+            "bar_mass": 60.0,
+            "body_params": {"body_mass": 80.0, "height": 1.80},
+            "arrays": {
+                k: getattr(result, k).tolist()
+                for k in ("t", "q", "qd", "qdd", "torques", "power", "com", "bar")
+            },
+            "metadata": {
+                "success": True,
+                "cost": 42.5,
+                "com_horizontal_range_cm": 3.2,
+                "elapsed_s": 1.5,
+                "n_evals": 100,
+            },
+        }
+
+    def test_round_trip_solution_includes_schema_version(self, tmp_path):
+        result = make_test_result()
+        path = tmp_path / "solution.json"
+        save_solution(str(path), result, {"body_mass": 80.0}, "squat", 60.0)
+
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        assert raw["schema_version"] == SCHEMA_VERSION
+
+        loaded = load_solution(str(path))
+        assert loaded["schema_version"] == SCHEMA_VERSION
+        assert loaded["exercise_type"] == "squat"
+
+    def test_missing_schema_version_raises(self, tmp_path):
+        payload = self._valid_solution_payload()
+        del payload["schema_version"]
+        path = tmp_path / "solution.json"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        with pytest.raises(InvalidStateFileError, match="schema_version"):
+            load_solution(str(path))
+
+    def test_unknown_schema_version_raises(self, tmp_path):
+        payload = self._valid_solution_payload()
+        payload["schema_version"] = 999
+        path = tmp_path / "solution.json"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        with pytest.raises(InvalidStateFileError, match="unsupported schema_version"):
+            load_solution(str(path))
+
+    def test_missing_required_key_raises(self, tmp_path):
+        payload = self._valid_solution_payload()
+        del payload["bar_mass"]
+        path = tmp_path / "solution.json"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        with pytest.raises(InvalidStateFileError, match="bar_mass"):
+            load_solution(str(path))
+
+    def test_wrong_type_for_bar_mass_raises(self, tmp_path):
+        payload = self._valid_solution_payload()
+        payload["bar_mass"] = "sixty"
+        path = tmp_path / "solution.json"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        with pytest.raises(InvalidStateFileError, match="bar_mass"):
+            load_solution(str(path))
+
+    def test_out_of_range_bar_mass_raises(self, tmp_path):
+        payload = self._valid_solution_payload()
+        payload["bar_mass"] = -10.0
+        path = tmp_path / "solution.json"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        with pytest.raises(InvalidStateFileError, match="out of range"):
+            load_solution(str(path))
+
+    def test_unknown_exercise_type_raises(self, tmp_path):
+        payload = self._valid_solution_payload()
+        payload["exercise_type"] = "moonwalk"
+        path = tmp_path / "solution.json"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        with pytest.raises(InvalidStateFileError, match="moonwalk"):
+            load_solution(str(path))
+
+    def test_arrays_field_not_list_raises(self, tmp_path):
+        payload = self._valid_solution_payload()
+        payload["arrays"]["t"] = "not a list"
+        path = tmp_path / "solution.json"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        with pytest.raises(InvalidStateFileError, match=r"arrays\.t"):
+            load_solution(str(path))
+
+    def test_metadata_missing_required_key_raises(self, tmp_path):
+        payload = self._valid_solution_payload()
+        del payload["metadata"]["cost"]
+        path = tmp_path / "solution.json"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        with pytest.raises(InvalidStateFileError, match="cost"):
+            load_solution(str(path))


### PR DESCRIPTION
## Summary

- Adds explicit schema validation to `persistence.py` so corrupt or out-of-spec JSON state files no longer slip through silently. Missing required keys, wrong value types, out-of-range numeric values, and unsupported `schema_version` values now raise `InvalidStateFileError` (a `ValueError` subclass) with messages that name the offending field.
- Stamps every saved file with `SCHEMA_VERSION = 1`. Files without a `schema_version` are rejected with a clear message; future format changes can either bump the version or implement a migration.
- The GUI session-restore path catches the new exception and surfaces it via a `QMessageBox.warning`, so users learn their saved state is incompatible instead of having it dropped on the floor. The solution-load dialog already caught `ValueError`, so it picks up the subclass automatically and now shows an "Invalid Solution File" title for the schema case.

## Test plan

- [x] `PYTHONPATH=src QT_QPA_PLATFORM=offscreen python3 -m pytest tests/ -q` -> 551 passed (532 baseline + 19 new schema tests)
- [x] `ruff check src/ tests/` -> all checks passed
- [x] `ruff format --check src/ tests/` -> 99 files already formatted
- [x] New tests cover: round-trip with `schema_version`, missing/unknown `schema_version`, missing required keys, wrong types (top-level and individual fields), out-of-range numeric values, unknown exercise types, malformed `arrays`/`metadata` blocks, and non-object top-level JSON.

Closes #403

https://claude.ai/code/session_01Vw3sFVXpaJrPRXrseq9dAL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vw3sFVXpaJrPRXrseq9dAL)_