### PR TITLE
fix: protect shared optimization state from race conditions (#407)

### DIFF
--- a/src/movement_optimizer/gui/animation_control.py
+++ b/src/movement_optimizer/gui/animation_control.py
@@ -21,7 +21,8 @@ class AnimationControlMixin:
 
     def _toggle_play(self: MainWindow) -> None:  # type: ignore[override]
         idx = self.tabs.currentIndex()
-        if self.results[idx] is None:
+        r, _fi, _body, _dyn = self._snapshot_idx_state(idx)
+        if r is None:
             return
         if self.is_playing:
             self._stop_anim()
@@ -39,84 +40,85 @@ class AnimationControlMixin:
         if not self.is_playing:
             return
         idx = self.tabs.currentIndex()
-        r = self.results[idx]
+        r, fi, body, dyn = self._snapshot_idx_state(idx)
         if r is None:
             return
 
-        fi = self.anim_frames[idx]
         _, etype = self.EXERCISE_CONFIGS[idx]
-        body = self.bodies_list[idx]
         if body is None:
             raise ValueError("DbC Blocked: Precondition failed.")
         self.exercise_tabs[idx].draw_anim_frame(
             fi,
             r,
-            self.dynamics_list[idx],
+            dyn,
             body,
             etype,
         )
 
         n = len(r.t)
-        self.anim_frames[idx] = (fi + 1) % n
+        next_frame = (fi + 1) % n
+        self._set_anim_frame(idx, next_frame)
         speed = self.controls.speed_multiplier()
         self.controls.set_playback_status(fi + 1, n, speed)
         delay = max(15, int(40 / max(0.1, speed)))
-        if self.anim_frames[idx] == 0:
+        if next_frame == 0:
             delay = 700
         self.anim_timer.start(delay)
 
     def _step_fwd(self: MainWindow) -> None:  # type: ignore[override]
         idx = self.tabs.currentIndex()
-        r = self.results[idx]
+        r, fi, body, dyn = self._snapshot_idx_state(idx)
         if r is None:
             return
         self._stop_anim()
         n = len(r.t)
-        self.anim_frames[idx] = (self.anim_frames[idx] + 1) % n
+        new_frame = (fi + 1) % n
+        self._set_anim_frame(idx, new_frame)
         _, etype = self.EXERCISE_CONFIGS[idx]
         self.exercise_tabs[idx].draw_anim_frame(
-            self.anim_frames[idx],
+            new_frame,
             r,
-            self.dynamics_list[idx],
-            self.bodies_list[idx],  # type: ignore[arg-type]
+            dyn,
+            body,  # type: ignore[arg-type]
             etype,
         )
         self.controls.set_playback_status(
-            self.anim_frames[idx] + 1,
+            new_frame + 1,
             n,
             self.controls.speed_multiplier(),
         )
 
     def _step_back(self: MainWindow) -> None:  # type: ignore[override]
         idx = self.tabs.currentIndex()
-        r = self.results[idx]
+        r, fi, body, dyn = self._snapshot_idx_state(idx)
         if r is None:
             return
         self._stop_anim()
         n = len(r.t)
-        self.anim_frames[idx] = (self.anim_frames[idx] - 1) % n
+        new_frame = (fi - 1) % n
+        self._set_anim_frame(idx, new_frame)
         _, etype = self.EXERCISE_CONFIGS[idx]
         self.exercise_tabs[idx].draw_anim_frame(
-            self.anim_frames[idx],
+            new_frame,
             r,
-            self.dynamics_list[idx],
-            self.bodies_list[idx],  # type: ignore[arg-type]
+            dyn,
+            body,  # type: ignore[arg-type]
             etype,
         )
 
     def _rewind(self: MainWindow) -> None:  # type: ignore[override]
         idx = self.tabs.currentIndex()
-        r = self.results[idx]
+        r, _fi, body, dyn = self._snapshot_idx_state(idx)
         if r is None:
             return
         self._stop_anim()
-        self.anim_frames[idx] = 0
+        self._set_anim_frame(idx, 0)
         _, etype = self.EXERCISE_CONFIGS[idx]
         self.exercise_tabs[idx].draw_anim_frame(
             0,
             r,
-            self.dynamics_list[idx],
-            self.bodies_list[idx],  # type: ignore[arg-type]
+            dyn,
+            body,  # type: ignore[arg-type]
             etype,
         )
 

--- a/src/movement_optimizer/gui/comparison_mixin.py
+++ b/src/movement_optimizer/gui/comparison_mixin.py
@@ -24,7 +24,7 @@ class ComparisonMixin:
 
     def _add_comparison(self: MainWindow) -> None:  # type: ignore[misc]
         idx = self.tabs.currentIndex()
-        r = self.results[idx]
+        r, _fi, _body, _dyn = self._snapshot_idx_state(idx)
         if r is None:
             return
         display_name, _etype = self.EXERCISE_CONFIGS[idx]

--- a/src/movement_optimizer/gui/file_operations.py
+++ b/src/movement_optimizer/gui/file_operations.py
@@ -32,7 +32,7 @@ class FileOperationsMixin:
 
     def _export(self: MainWindow) -> None:  # type: ignore[misc]
         idx = self.tabs.currentIndex()
-        r = self.results[idx]
+        r, _fi, _body, _dyn = self._snapshot_idx_state(idx)
         if r is None:
             return
         name = self.EXERCISE_CONFIGS[idx][0].lower().replace(" ", "_")
@@ -48,7 +48,7 @@ class FileOperationsMixin:
 
     def _save_solution(self: MainWindow) -> None:  # type: ignore[misc]
         idx = self.tabs.currentIndex()
-        r = self.results[idx]
+        r, _fi, _body, _dyn = self._snapshot_idx_state(idx)
         if r is None:
             return
         name = self.EXERCISE_CONFIGS[idx][0].lower().replace(" ", "_")
@@ -96,7 +96,7 @@ class FileOperationsMixin:
 
     def _export_video(self: MainWindow) -> None:  # type: ignore[misc]
         idx = self.tabs.currentIndex()
-        r = self.results[idx]
+        r, _fi, body, dyn = self._snapshot_idx_state(idx)
         if r is None:
             return
         name = self.EXERCISE_CONFIGS[idx][0].lower().replace(" ", "_")
@@ -111,8 +111,6 @@ class FileOperationsMixin:
         try:
             tab = self.exercise_tabs[idx]
             _, etype = self.EXERCISE_CONFIGS[idx]
-            body = self.bodies_list[idx]
-            dyn = self.dynamics_list[idx]
             n_frames = len(r.t)
 
             if body is None:
@@ -129,7 +127,7 @@ class FileOperationsMixin:
 
     def _export_plots(self: MainWindow) -> None:  # type: ignore[misc]
         idx = self.tabs.currentIndex()
-        r = self.results[idx]
+        r, _fi, _body, _dyn = self._snapshot_idx_state(idx)
         if r is None:
             return
         name = self.EXERCISE_CONFIGS[idx][0].lower().replace(" ", "_")

--- a/src/movement_optimizer/gui/main_window.py
+++ b/src/movement_optimizer/gui/main_window.py
@@ -107,7 +107,9 @@ class MainWindow(
 
         self._cancel_event = threading.Event()
         self._opt_running = False
-        self._opt_lock = threading.Lock()
+        # RLock so the same thread may re-enter critical sections without
+        # deadlocking when one locked helper calls another locked helper.
+        self._opt_lock = threading.RLock()
         self._cache = SolutionCache()
         self._comparison_store = ComparisonStore()
         self._last_config: tuple[Any, ...] = ()

--- a/src/movement_optimizer/gui/optimization_mixin.py
+++ b/src/movement_optimizer/gui/optimization_mixin.py
@@ -28,8 +28,14 @@ logger = logging.getLogger(__name__)
 class OptimizationMixin:
     """Contains logic for preparing and running optimization backgrounds tasks."""
 
-    # These attributes are expected to be present on the MainWindow instance
-    _opt_lock: threading.Lock
+    # These attributes are expected to be present on the MainWindow instance.
+    # ``_opt_lock`` is an RLock so the same thread may re-enter critical
+    # sections (e.g. a locked helper calling another locked helper) without
+    # deadlocking. All writes to ``results``/``anim_frames``/``bodies_list``/
+    # ``dynamics_list`` (and corresponding cross-thread reads) must hold this
+    # lock to prevent torn updates between the worker thread and the GUI
+    # main thread.
+    _opt_lock: threading.RLock
     _opt_running: bool
     _cache: SolutionCache
     _cancel_event: threading.Event
@@ -43,6 +49,28 @@ class OptimizationMixin:
     def __init__(self) -> None:
         """Init."""
         pass
+
+    def _snapshot_idx_state(
+        self, idx: int
+    ) -> tuple[OptimizationResult | None, int, BodyModel | None, Any]:
+        """Return a consistent snapshot of (result, anim_frame, body, dyn) for ``idx``.
+
+        Acquires ``_opt_lock`` briefly to copy the four shared per-index values
+        out so callers can work with the snapshot outside the critical section,
+        avoiding torn reads while the worker thread is publishing a new result.
+        """
+        with self._opt_lock:
+            return (
+                self.results[idx],
+                self.anim_frames[idx],
+                self.bodies_list[idx],
+                self.dynamics_list[idx],
+            )
+
+    def _set_anim_frame(self, idx: int, frame: int) -> None:
+        """Atomically write ``anim_frames[idx]`` under the optimizer lock."""
+        with self._opt_lock:
+            self.anim_frames[idx] = frame
 
     def _resolve_exercise_params(self, idx: int) -> tuple[Any, Any, str, float, float, float]:
         body = self.sidebar.get_body_model()  # type: ignore[attr-defined]
@@ -67,9 +95,10 @@ class OptimizationMixin:
         if etype in _min_durations:
             dur = max(dur, _min_durations[etype])
 
-        self.dynamics_list[idx] = dyn
-        self.bodies_list[idx] = body
-        self._last_config = (dyn, qs, qe, qb, q_via, etype)
+        with self._opt_lock:
+            self.dynamics_list[idx] = dyn
+            self.bodies_list[idx] = body
+            self._last_config = (dyn, qs, qe, qb, q_via, etype)
         return body, dyn, etype, bar, dur, smoothness
 
     def _seg_mults(self) -> dict[str, float]:
@@ -127,8 +156,9 @@ class OptimizationMixin:
             )
             if cached is not None:
                 logger.info("Cache hit for %s", etype)
-                self.results[idx] = cached
-                self.anim_frames[idx] = 0
+                with self._opt_lock:
+                    self.results[idx] = cached
+                    self.anim_frames[idx] = 0
                 self._sig_done.emit(idx, cached, body, bar, then_chain)  # type: ignore[attr-defined]
                 return
 
@@ -185,7 +215,9 @@ class OptimizationMixin:
             self._update_result_summary(name, result, exercise_type=etype)
             tab = self.exercise_tabs[idx]  # type: ignore[attr-defined]
             tab.draw_all_plots(result, body, bar, exercise_type=etype)
-            tab.draw_anim_frame(0, result, self.dynamics_list[idx], body, etype)  # type: ignore[attr-defined]
+            with self._opt_lock:  # type: ignore[attr-defined]
+                dyn = self.dynamics_list[idx]
+            tab.draw_anim_frame(0, result, dyn, body, etype)  # type: ignore[attr-defined]
             elapsed = result.elapsed_s
             t_str = (
                 f"{elapsed:.1f}s" if elapsed < 60 else f"{int(elapsed // 60)}m {elapsed % 60:.0f}s"

--- a/src/movement_optimizer/gui/session_state.py
+++ b/src/movement_optimizer/gui/session_state.py
@@ -13,10 +13,16 @@ if TYPE_CHECKING:
 
 
 def collect_results(window: MainWindow) -> dict[str, OptimizationResult]:
-    """Collect non-null exercise results keyed by exercise type."""
+    """Collect non-null exercise results keyed by exercise type.
+
+    Briefly acquires ``window._opt_lock`` so the snapshot is consistent with
+    the worker thread's writes to ``window.results``.
+    """
+    with window._opt_lock:
+        snapshot = list(window.results)
     results: dict[str, OptimizationResult] = {}
     for index, (_, exercise_type) in enumerate(window.EXERCISE_CONFIGS):
-        result = window.results[index]
+        result = snapshot[index]
         if result is not None:
             results[exercise_type] = result
     return results

--- a/tests/test_session_state.py
+++ b/tests/test_session_state.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import threading
 from dataclasses import dataclass
 from typing import ClassVar
 
@@ -47,6 +48,8 @@ class _FakeWindow:
 
     def __init__(self) -> None:
         self.results = [make_test_result(cost=10.0), None, make_test_result(cost=20.0)]
+        # collect_results acquires this lock to take a consistent snapshot.
+        self._opt_lock = threading.RLock()
 
 
 class TestSessionState:

--- a/tests/test_thread_safety.py
+++ b/tests/test_thread_safety.py
@@ -1,0 +1,234 @@
+# Copyright (c) 2026 D-Sorganization. All rights reserved.
+"""Thread-safety tests for shared optimizer state on MainWindow.
+
+Issue #407: results, anim_frames, bodies_list, and dynamics_list are written
+from worker threads (running ``_opt_worker``) and read from the GUI main
+thread (signal handlers, animation, file I/O). These tests exercise
+concurrent writers/readers against the OptimizationMixin lock helpers and
+verify that no torn snapshots, lost updates, or deadlocks occur.
+
+Tests must run headless. ``QT_QPA_PLATFORM=offscreen`` is set in the module
+``conftest`` fixture so they pass on CI without a display.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+from typing import Any, ClassVar
+
+# Force the offscreen Qt platform before any Qt import (defensive — also set
+# by the harness command line). The OptimizationMixin code path under test
+# does not actually require Qt, but importing main_window does.
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from conftest import make_test_result
+
+from movement_optimizer.gui.optimization_mixin import OptimizationMixin
+
+
+class _ThreadSafetyHarness:
+    """Minimal harness exposing the four shared lists plus _opt_lock.
+
+    Mirrors the relevant attributes of MainWindow so the mixin's
+    ``_snapshot_idx_state`` / ``_set_anim_frame`` helpers can be exercised
+    directly without bringing up a Qt window.
+    """
+
+    EXERCISE_CONFIGS: ClassVar = (
+        ("Squat", "squat"),
+        ("Full Squat", "full_squat"),
+        ("Deadlift", "deadlift"),
+        ("Bench", "bench_press"),
+    )
+
+    def __init__(self) -> None:
+        n = len(self.EXERCISE_CONFIGS)
+        self.results: list[Any] = [None] * n
+        self.dynamics_list: list[Any] = [None] * n
+        self.bodies_list: list[Any] = [None] * n
+        self.anim_frames: list[int] = [0] * n
+        # RLock so re-entrant locking does not deadlock.
+        self._opt_lock = threading.RLock()
+
+
+def _join_with_timeout(threads: list[threading.Thread], timeout: float) -> None:
+    """Join all threads. If any are still alive after ``timeout`` total
+    seconds, fail the test loudly with a deadlock message instead of
+    hanging the test runner.
+    """
+    deadline = threading.Event()
+
+    def _set_deadline() -> None:
+        deadline.set()
+
+    timer = threading.Timer(timeout, _set_deadline)
+    timer.daemon = True
+    timer.start()
+    try:
+        for t in threads:
+            remaining = max(0.05, timeout)
+            t.join(timeout=remaining)
+            if t.is_alive():
+                raise AssertionError(
+                    f"Thread {t.name!r} did not finish within {timeout}s "
+                    "-- possible deadlock in shared-state locking"
+                )
+    finally:
+        timer.cancel()
+    assert not deadline.is_set() or all(not t.is_alive() for t in threads)
+
+
+# ---------------------------------------------------------------------------
+# Test 1: concurrent writers + reader produce coherent snapshots
+# ---------------------------------------------------------------------------
+
+
+class TestConcurrentSnapshot:
+    """A reader running ``_snapshot_idx_state`` should never observe a
+    torn state -- e.g., a ``result`` from iteration N paired with a
+    ``body``/``dyn`` from iteration M.
+    """
+
+    def test_no_torn_snapshots_under_contention(self) -> None:
+        harness = _ThreadSafetyHarness()
+        idx = 0
+        n_iters = 200
+        stop = threading.Event()
+        observations: list[tuple[int, int, int, int]] = []
+        errors: list[BaseException] = []
+
+        def writer() -> None:
+            try:
+                for i in range(1, n_iters + 1):
+                    # Tag each iteration with its iteration counter so a
+                    # torn read becomes detectable as mismatched ``cost``
+                    # vs. body/dyn marker fields.
+                    res = make_test_result(cost=float(i))
+                    body_marker = ("body", i)
+                    dyn_marker = ("dyn", i)
+                    with harness._opt_lock:
+                        harness.results[idx] = res
+                        harness.bodies_list[idx] = body_marker
+                        harness.dynamics_list[idx] = dyn_marker
+                        harness.anim_frames[idx] = i
+            except BaseException as exc:  # pragma: no cover - debug aid
+                errors.append(exc)
+                stop.set()
+
+        def reader() -> None:
+            try:
+                while not stop.is_set():
+                    snap = OptimizationMixin._snapshot_idx_state(harness, idx)  # type: ignore[arg-type]
+                    r, fi, body, dyn = snap
+                    if r is None:
+                        continue
+                    cost = int(r.cost)
+                    body_iter = body[1] if isinstance(body, tuple) else None
+                    dyn_iter = dyn[1] if isinstance(dyn, tuple) else None
+                    observations.append((cost, fi, body_iter or 0, dyn_iter or 0))
+            except BaseException as exc:  # pragma: no cover - debug aid
+                errors.append(exc)
+                stop.set()
+
+        w = threading.Thread(target=writer, name="writer")
+        r1 = threading.Thread(target=reader, name="reader-1")
+        r2 = threading.Thread(target=reader, name="reader-2")
+        w.start()
+        r1.start()
+        r2.start()
+        w.join(timeout=10.0)
+        stop.set()
+        _join_with_timeout([r1, r2], timeout=5.0)
+
+        assert not errors, f"Worker threads raised: {errors!r}"
+        assert observations, "Reader threads never observed any state"
+        # For every snapshot, all four "iteration" markers must agree --
+        # if they ever differ, locking failed to provide atomicity.
+        for cost, fi, body_iter, dyn_iter in observations:
+            assert cost == fi == body_iter == dyn_iter, (
+                f"Torn snapshot detected: cost={cost} frame={fi} "
+                f"body_iter={body_iter} dyn_iter={dyn_iter}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Test 2: concurrent ``_set_anim_frame`` writers do not lose updates
+# ---------------------------------------------------------------------------
+
+
+class TestConcurrentAnimFrameWrites:
+    """All anim-frame writes from many threads must be observable; the final
+    state must match exactly one of the values written, not a corrupted one.
+    """
+
+    def test_set_anim_frame_is_atomic(self) -> None:
+        harness = _ThreadSafetyHarness()
+        idx = 1
+        per_thread = 500
+        n_threads = 8
+        errors: list[BaseException] = []
+
+        def worker(start: int) -> None:
+            try:
+                for v in range(start, start + per_thread):
+                    OptimizationMixin._set_anim_frame(harness, idx, v)  # type: ignore[arg-type]
+            except BaseException as exc:  # pragma: no cover
+                errors.append(exc)
+
+        threads = [
+            threading.Thread(target=worker, args=(t * per_thread,), name=f"w{t}")
+            for t in range(n_threads)
+        ]
+        for t in threads:
+            t.start()
+        _join_with_timeout(threads, timeout=10.0)
+
+        assert not errors, f"Workers raised: {errors!r}"
+        # Final value must be a non-negative int that some worker wrote --
+        # a corrupted/non-int value here would mean the list slot was being
+        # mutated mid-read by another thread.
+        final = harness.anim_frames[idx]
+        assert isinstance(final, int)
+        assert 0 <= final < n_threads * per_thread
+
+
+# ---------------------------------------------------------------------------
+# Test 3: re-entrant lock acquisition does not deadlock
+# ---------------------------------------------------------------------------
+
+
+class TestReentrantLockNoDeadlock:
+    """Some code paths (notably ``_resolve_exercise_params`` calling
+    ``_snapshot_idx_state`` would-be wrappers) acquire ``_opt_lock`` from
+    inside another locked section. Using ``threading.RLock`` permits this;
+    a plain ``Lock`` would deadlock. This test guards that invariant.
+    """
+
+    def test_nested_acquisition_completes(self) -> None:
+        harness = _ThreadSafetyHarness()
+        completed = threading.Event()
+        errors: list[BaseException] = []
+
+        def runner() -> None:
+            try:
+                with harness._opt_lock:
+                    # Helper itself acquires _opt_lock again -- only safe
+                    # because the lock is reentrant.
+                    snap = OptimizationMixin._snapshot_idx_state(harness, 0)  # type: ignore[arg-type]
+                    assert snap == (None, 0, None, None)
+                    OptimizationMixin._set_anim_frame(harness, 0, 7)  # type: ignore[arg-type]
+                completed.set()
+            except BaseException as exc:  # pragma: no cover
+                errors.append(exc)
+
+        t = threading.Thread(target=runner, name="reentrant", daemon=True)
+        t.start()
+        t.join(timeout=2.0)
+
+        assert not t.is_alive(), (
+            "Re-entrant lock acquisition deadlocked -- _opt_lock must be an RLock"
+        )
+        assert not errors, f"Runner raised: {errors!r}"
+        assert completed.is_set()
+        assert harness.anim_frames[0] == 7


### PR DESCRIPTION
## Summary

Fixes the inconsistent lock coverage on `MainWindow.results` / `anim_frames` / `bodies_list` / `dynamics_list`. Closes #407.

The optimizer worker thread and the GUI main thread both touch those four shared lists, but several mutation sites and every reader were running outside `_opt_lock`. That allowed torn reads (e.g. a freshly-published `result` paired with a stale `body`/`dyn`) and lost updates.

## Changes

- **`gui/main_window.py`**: `_opt_lock` is now `threading.RLock()` so re-entry is safe when one locked helper calls another.
- **`gui/optimization_mixin.py`**:
  - All writes in `_resolve_exercise_params` (`dynamics_list[idx]`, `bodies_list[idx]`, `_last_config`) are now wrapped in `with self._opt_lock:`.
  - The cache-hit branch of `_opt_worker` now publishes `results[idx]` and `anim_frames[idx]` atomically under the lock (previously only the non-cache branch did).
  - `_on_done` reads `dynamics_list[idx]` under the lock before drawing.
  - New helpers `_snapshot_idx_state(idx)` (returns `(result, anim_frame, body, dyn)` atomically) and `_set_anim_frame(idx, frame)`.
- **`gui/animation_control.py`**: `_toggle_play`, `_anim_step`, `_step_fwd`, `_step_back`, `_rewind` use `_snapshot_idx_state` to copy out shared state under the lock and `_set_anim_frame` to write back.
- **`gui/file_operations.py`**: `_export`, `_save_solution`, `_export_video`, `_export_plots` use `_snapshot_idx_state` for their reads.
- **`gui/comparison_mixin.py`**: `_add_comparison` uses `_snapshot_idx_state`.
- **`gui/session_state.py`**: `collect_results` snapshots `window.results` under the lock so close-time persistence is consistent with worker writes.

No public API changes. No new abstractions.

## Tests

- New `tests/test_thread_safety.py` (3 tests, all pass headlessly under `QT_QPA_PLATFORM=offscreen`):
  - `TestConcurrentSnapshot.test_no_torn_snapshots_under_contention` — a writer thread tags each iteration with a counter across all four lists and two reader threads verify that every snapshot has matching markers.
  - `TestConcurrentAnimFrameWrites.test_set_anim_frame_is_atomic` — 8 threads × 500 writes each; final value is a valid integer.
  - `TestReentrantLockNoDeadlock.test_nested_acquisition_completes` — guards against regressing back to a plain `Lock`.
- `tests/test_session_state.py`: `_FakeWindow` now provides `_opt_lock`, since `collect_results` acquires it.
- All threading tests use `thread.join(timeout=...)` so a deadlock fails the test loudly instead of hanging the runner.

## Test plan

- [x] `PYTHONPATH=src QT_QPA_PLATFORM=offscreen python3 -m pytest tests/ -q` — 535 passed (was 532; +3 new).
- [x] `ruff check src/ tests/` — passes.
- [x] `ruff format src/ tests/` — clean.

Closes #407.

https://claude.ai/code/session_01Vw3sFVXpaJrPRXrseq9dAL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vw3sFVXpaJrPRXrseq9dAL)_