### PR TITLE
docs: add docstrings to core public API (#408)

### DIFF
--- a/src/movement_optimizer/__init__.py
+++ b/src/movement_optimizer/__init__.py
@@ -3,6 +3,19 @@
 
 A biomechanics tool for optimising exercise movement trajectories
 using Lagrangian inverse dynamics in the sagittal plane.
+
+Top-level exports:
+    balance_pose: Helper that adjusts a raw pose so the COM lies inside
+        the base of support.
+    __version__: Installed package version (``"0.0.0.dev0"`` when running
+        from a source checkout that is not pip-installed).
+
+Most users will import the major API surfaces from sub-packages:
+    ``movement_optimizer.models`` -- ``BodyModel``, ``LagrangianDynamics``.
+    ``movement_optimizer.trajectory`` -- ``TrajectoryOptimizer``,
+        ``OptimizationResult``.
+    ``movement_optimizer.exercises`` -- per-exercise configuration
+        factories (``make_clean_config``, ``make_snatch_config``, ...).
 """
 
 from __future__ import annotations

--- a/src/movement_optimizer/exercises/__init__.py
+++ b/src/movement_optimizer/exercises/__init__.py
@@ -1,5 +1,22 @@
 # Copyright (c) 2026 D-Sorganization. All rights reserved.
-"""Exercise configuration factories."""
+"""Exercise configuration factories.
+
+Each ``make_*_config`` factory returns a tuple
+``(dynamics, q_start, q_end, q_bounds, q_via)`` (or via-points list, for
+gait and sit-to-stand) that can be fed directly into
+:class:`movement_optimizer.trajectory.TrajectoryOptimizer`.
+
+Public exports:
+    make_clean_config: Olympic clean (floor to front rack).
+    make_snatch_config: Olympic snatch (floor to overhead).
+    make_jerk_config: Jerk drive (front rack to overhead lockout).
+    make_gait_config: One full gait cycle (heel strike to heel strike).
+    make_sit_to_stand_config: Seated to standing transition.
+    GaitAnalyzer: Spatiotemporal and symmetry analysis for gait.
+
+Squat, deadlift, and bench press factories live in
+``movement_optimizer.models`` for historical reasons.
+"""
 
 from .clean import make_clean_config as make_clean_config
 from .gait import GaitAnalyzer as GaitAnalyzer

--- a/src/movement_optimizer/models/body_model.py
+++ b/src/movement_optimizer/models/body_model.py
@@ -86,10 +86,15 @@ class BodyModel:
                 leg lengths into the sagittal plane (default 0).
             arm_angle: Arm elevation angle in degrees used for bench press
                 sagittal projection (default 0).
+            squat_bar_depth: Horizontal offset (m) of the bar behind the
+                shoulder for low-bar squat geometry (must be >= 0).
+            squat_bar_height: Vertical offset (m) of the bar below the
+                top of the torso (must be >= 0).
 
         Raises:
-            ValueError: If body_mass or height are not positive, or any
-                segment multiplier is outside [0.5, 2.0].
+            ValueError: If body_mass or height are not positive, any
+                segment multiplier is outside [0.5, 2.0], or either
+                squat-bar offset is negative.
         """
         if body_mass <= 0:
             raise ValueError("body_mass must be positive")

--- a/src/movement_optimizer/trajectory/optimizer.py
+++ b/src/movement_optimizer/trajectory/optimizer.py
@@ -86,6 +86,38 @@ class TrajectoryOptimizer:
         progress_cb: Callable[[ProgressReport], None] | None = None,
         cancel_event: threading.Event | None = None,
     ) -> None:
+        """Configure a multi-start trajectory optimiser.
+
+        Args:
+            body: Anthropometric model providing inner-BOS bounds.
+            dynamics: Physics backend implementing :class:`PhysicsBackend`.
+            exercise_type: Identifier such as ``"squat"`` or ``"deadlift"``;
+                selects the COM model and balance constraint.
+            bar_mass: External barbell load in kg.
+            q_start: Initial joint-angle vector, shape ``(n_dof,)`` in rad.
+            q_end: Final joint-angle vector, shape ``(n_dof,)`` in rad.
+            q_bounds: Per-joint ``(lo, hi)`` limits, shape ``(n_dof, 2)``.
+            q_via: Optional intermediate waypoint inserted at the time-grid
+                midpoint. Defaults to None.
+            duration: Movement duration in seconds.
+            n_waypoints: Number of free interior control points (must be
+                >= 4).
+            n_eval: Number of evaluation samples on the dense grid.
+            jerk_weight: Weight on integrated squared jerk.
+            torque_rate_weight: Weight on integrated squared torque rate.
+            endpoint_weight: Weight on endpoint velocity/acceleration damping.
+            smoothness: Global multiplier applied to the three
+                smoothness weights above.
+            n_starts: Number of multi-start SLSQP runs to launch.
+            progress_cb: Optional callback receiving :class:`ProgressReport`
+                snapshots.
+            cancel_event: Optional event; setting it terminates
+                :meth:`optimize` with :class:`CancelledError`.
+
+        Raises:
+            ValueError: If ``n_waypoints < 4`` or ``q_bounds`` has the
+                wrong shape.
+        """
         if n_waypoints < 4:
             raise ValueError("need >= 4 waypoints")
         n_dof = q_bounds.shape[0]
@@ -259,7 +291,18 @@ class TrajectoryOptimizer:
         )
 
     def optimize(self) -> OptimizationResult:
-        """Run parallel multi-start SLSQP and return best result.
+        """Run parallel multi-start SLSQP and return the best result.
+
+        Each start launches an SLSQP run with bounds and inner-BOS
+        constraints; the start with the lowest feasible cost wins.
+
+        Returns:
+            :class:`OptimizationResult` populated with the best
+            trajectory, cost, timing, and feasibility metadata.
+
+        Raises:
+            CancelledError: If ``cancel_event`` was set before the
+                optimisation produced any feasible result.
 
         Complexity:
             O(S * I * (W + N)) total work for fixed 3-DOF trajectories, where

--- a/src/movement_optimizer/trajectory/result.py
+++ b/src/movement_optimizer/trajectory/result.py
@@ -10,7 +10,26 @@ from numpy.typing import NDArray
 
 @dataclass
 class OptimizationResult:
-    """Immutable container for optimiser output."""
+    """Container for optimiser output.
+
+    Attributes:
+        t: Time grid, shape ``(N,)`` in seconds.
+        q: Joint angles, shape ``(N, n_dof)`` in radians.
+        qd: Joint velocities, shape ``(N, n_dof)`` in rad/s.
+        qdd: Joint accelerations, shape ``(N, n_dof)`` in rad/s^2.
+        torques: Joint torques, shape ``(N, n_dof)`` in N*m.
+        power: Per-joint mechanical power, shape ``(N, n_dof)`` in W.
+        com: Whole-body COM trajectory ``(x, y)``, shape ``(N, 2)`` in m.
+        bar: Barbell trajectory ``(x, y)``, shape ``(N, 2)`` in m.
+        success: True when the optimiser converged and all hard
+            constraints (COM in inner BOS, joint limits) are satisfied.
+        cost: Final scalar cost (lower is better).
+        com_horizontal_range_cm: Peak-to-peak horizontal COM excursion.
+        elapsed_s: Wall-clock seconds spent in :meth:`optimize`.
+        n_evals: Total cost evaluations across all starts.
+        n_joint_limit_violations: Number of trajectory samples whose
+            joint angles fall outside ``q_bounds``.
+    """
 
     t: NDArray
     q: NDArray
@@ -30,7 +49,18 @@ class OptimizationResult:
 
 @dataclass
 class ProgressReport:
-    """Snapshot of optimiser state for the GUI."""
+    """Snapshot of optimiser state emitted to a progress callback.
+
+    Attributes:
+        iteration: Cost evaluation counter.
+        cost: Current cost value.
+        best_cost: Best cost seen so far.
+        improvement_pct: Percent improvement over the previous report.
+        elapsed_s: Seconds since :meth:`optimize` started.
+        cost_history: Running list of all observed cost values.
+        is_stalled: True when the heuristic stall detector triggered.
+        stall_reason: Human-readable reason when ``is_stalled``.
+    """
 
     iteration: int
     cost: float
@@ -43,4 +73,4 @@ class ProgressReport:
 
 
 class CancelledError(Exception):
-    """Raised when the user cancels optimisation."""
+    """Raised when the user cancels optimisation via ``cancel_event``."""


### PR DESCRIPTION
## Summary
- Add Google-style docstrings to the core public API surfaces a downstream user is most likely to import.
- Expand top-level and `exercises` package docstrings to enumerate public exports.
- Document `TrajectoryOptimizer.__init__` (Args + Raises) and add `Returns`/`Raises` to `optimize()`.
- Add `Attributes:` blocks to `OptimizationResult` and `ProgressReport`; clarify `CancelledError`.
- Document the previously undocumented `squat_bar_depth` and `squat_bar_height` args on `BodyModel`.

Files left untouched because their existing docstrings were already comprehensive: `backend.py` (`PhysicsBackend`), per-exercise factory modules (`clean.py`, `snatch.py`, `jerk.py`, `gait.py`, `sit_to_stand.py`), and `_common.py` helpers.

No behavior changes -- pure docstring additions. Private helpers and obvious one-liners were skipped per the issue scope.

## Test plan
- [x] `ruff check src/` passes
- [x] `ruff format src/` is a no-op
- [x] `PYTHONPATH=src QT_QPA_PLATFORM=offscreen python3 -m pytest tests/ -q` -- 532 passed
- [x] `python3 -c "import movement_optimizer; help(movement_optimizer)"` renders the new top-level module docstring cleanly

Closes #408

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vw3sFVXpaJrPRXrseq9dAL)_