### PR TITLE
fix: GUI cancel responsiveness and accessible button names (#401)

### DIFF
--- a/src/movement_optimizer/gui/_sidebar_state.py
+++ b/src/movement_optimizer/gui/_sidebar_state.py
@@ -38,6 +38,10 @@ def show_idle(sidebar) -> None:
     sidebar.both_btn.setToolTip(
         "Start trajectory optimization sequentially for all exercise tabs (Ctrl+Shift+R)"
     )
+    # Restore cancel button to its default text/state before hiding it so that
+    # the next optimization run starts with a clean button label.
+    sidebar.cancel_btn.setText("✖  Cancel")
+    sidebar.cancel_btn.setEnabled(True)
     sidebar.cancel_btn.setVisible(False)
 
 

--- a/src/movement_optimizer/gui/main_window.py
+++ b/src/movement_optimizer/gui/main_window.py
@@ -23,6 +23,7 @@ from typing import Any
 
 import matplotlib
 from PyQt6.QtCore import QSettings, QTimer, pyqtSignal
+from PyQt6.QtGui import QKeySequence, QShortcut
 from PyQt6.QtWidgets import (
     QMainWindow,
     QMessageBox,
@@ -137,6 +138,11 @@ class MainWindow(
         self._connect_signals()
 
     def _connect_signals(self) -> None:
+        # Window-level Escape shortcut for cancel — works even when the cancel
+        # button is hidden (QPushButton.setShortcut is inactive for hidden buttons).
+        self._esc_shortcut = QShortcut(QKeySequence("Escape"), self)
+        self._esc_shortcut.activated.connect(self._cancel_optimization)
+
         self.sidebar.connect_action_handlers(
             {
                 "optimize_current": self._run_current,
@@ -212,9 +218,12 @@ class MainWindow(
             self.tabs.setCurrentIndex(tab_idx)
 
     def _cancel_optimization(self) -> None:
+        with self._opt_lock:
+            if not self._opt_running:
+                return
         self._cancel_event.set()
         self.status_label.setText("Cancelling...")
-        self.sidebar.set_cancellation_available(False)
+        self.sidebar.set_cancelling()
 
     def _run_current(self) -> None:
         self._run_exercise(self.tabs.currentIndex())

--- a/src/movement_optimizer/gui/optimization_mixin.py
+++ b/src/movement_optimizer/gui/optimization_mixin.py
@@ -163,6 +163,14 @@ class OptimizationMixin:
 
     def _make_progress_cb(self) -> Callable[[ProgressReport], None]:
         def cb(report: ProgressReport) -> None:
+            logger.debug(
+                "iter=%d cost=%.3f best=%.3f improve=%+.3f%% elapsed=%.1fs",
+                report.iteration,
+                report.cost,
+                report.best_cost,
+                report.improvement_pct,
+                report.elapsed_s,
+            )
             self._sig_progress.emit(report)  # type: ignore[attr-defined]
 
         return cb

--- a/src/movement_optimizer/gui/parameter_sidebar.py
+++ b/src/movement_optimizer/gui/parameter_sidebar.py
@@ -239,3 +239,20 @@ class ParameterSidebar(QScrollArea):
             self.cancel_btn.setToolTip("Cancellation already requested, shutting down safely...")
         else:
             self.cancel_btn.setToolTip("Cancel the currently running optimization (Esc)")
+
+    def set_cancelling(self) -> None:
+        """Immediately reflect cancellation in the UI and flush pending events.
+
+        Disables the Run buttons and changes the cancel button text to
+        "Canceling…" so the user gets instant visual feedback, then calls
+        ``QApplication.processEvents()`` to keep the UI responsive while the
+        background thread winds down.
+        """
+        from PyQt6.QtWidgets import QApplication
+
+        self.opt_btn.setEnabled(False)
+        self.both_btn.setEnabled(False)
+        self.cancel_btn.setEnabled(False)
+        self.cancel_btn.setText("Canceling…")
+        self.cancel_btn.setToolTip("Cancellation already requested, shutting down safely...")
+        QApplication.processEvents()

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -182,6 +182,9 @@ class _FakeSidebar:
     def set_cancellation_available(self, available: bool) -> None:
         self.cancel_btn.enabled = available
 
+    def set_cancelling(self) -> None:
+        self.cancel_btn.enabled = False
+
 
 class _FakeTab:
     """Surrogate for ExerciseTab — records draw calls."""
@@ -372,6 +375,7 @@ class TestCancelOptimization:
         from movement_optimizer.gui.main_window import MainWindow
 
         window = _FakeWindow()
+        window._opt_running = True  # guard only fires when optimization is active
         window.sidebar.cancel_btn.enabled = True
 
         MainWindow._cancel_optimization(window)  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

Closes #401

- **Instant cancel feedback**: `_cancel_optimization()` now calls the new `sidebar.set_cancelling()` method, which immediately disables the Run buttons, changes the cancel button text to "Canceling…", and calls `QApplication.processEvents()` so the UI stays responsive while the background thread winds down.
- **Escape shortcut robustness**: Added a window-level `QShortcut(Escape)` in `_connect_signals()` that guards on `_opt_running`; `QPushButton.setShortcut` is inactive for hidden buttons, so this ensures Esc always reaches the cancel handler during an active optimization.
- **Clean button state on restore**: `show_idle()` now resets the cancel button text and enabled state before hiding it, so every new optimization run starts with a clean label.
- **Debug-level progress logging**: `_make_progress_cb()` logs iteration, cost, best cost, improvement %, and elapsed time at `DEBUG` level for easier diagnostics without polluting normal output.

## Test plan

- [ ] Start an optimization, press Escape — cancel button should immediately show "Canceling…" and Run buttons should disable; optimizer cancels within the next check cycle
- [ ] Click the Cancel button — same instant feedback as above
- [ ] After cancellation completes, verify Run buttons re-enable and cancel button resets to "✖  Cancel" for the next run
- [ ] Start and finish a normal optimization — verify no regression in progress display or button state
- [ ] Run `PYTHONPATH=src python3 -m pytest tests/ -v` — all tests pass
- [ ] Run `ruff check src/ tests/` — no lint errors

https://claude.ai/code/session_01N2iX3QcDw2cQ7ajpSUbcbA

---
_Generated by [Claude Code](https://claude.ai/code/session_01N2iX3QcDw2cQ7ajpSUbcbA)_