### PR TITLE
feat: help menu, parameter guide dialog, and improved tooltips (#414)

### DIFF
--- a/src/movement_optimizer/gui/_sidebar_builders.py
+++ b/src/movement_optimizer/gui/_sidebar_builders.py
@@ -32,8 +32,26 @@ logger = logging.getLogger(__name__)
 def build_body_params(sidebar) -> None:
     grp = QGroupBox("Body Parameters")
     lay = QVBoxLayout(grp)
-    sidebar.mass_slider = LabelledSlider("Body Mass", 40, 150, 75, "kg", 0)
-    sidebar.height_slider = LabelledSlider("Height", 1.40, 2.10, 1.75, "m", 2)
+    sidebar.mass_slider = LabelledSlider(
+        "Body Mass (kg)",
+        40,
+        150,
+        75,
+        "kg",
+        0,
+        tooltip="Body mass of the lifter in kilograms (typically 50-150 kg)."
+        " Affects segment inertia and gravitational loading throughout the movement.",
+    )
+    sidebar.height_slider = LabelledSlider(
+        "Height (m)",
+        1.40,
+        2.10,
+        1.75,
+        "m",
+        2,
+        tooltip="Standing height of the lifter in metres (typically 1.40-2.10 m)."
+        " Used to scale all segment lengths via anthropometric fractions.",
+    )
     lay.addWidget(sidebar.mass_slider)
     lay.addWidget(sidebar.height_slider)
     sidebar.main_layout.addWidget(grp)
@@ -45,9 +63,36 @@ def build_segment_lengths(sidebar) -> None:
     hint = QLabel("Multipliers on base length")
     hint.setProperty("class", "dim")
     lay.addWidget(hint)
-    sidebar.ll_slider = LabelledSlider("Lower Leg", 0.70, 1.30, 1.00, "x", 2)
-    sidebar.ul_slider = LabelledSlider("Upper Leg", 0.70, 1.30, 1.00, "x", 2)
-    sidebar.to_slider = LabelledSlider("Torso", 0.70, 1.30, 1.00, "x", 2)
+    sidebar.ll_slider = LabelledSlider(
+        "Lower Leg (x)",
+        0.70,
+        1.30,
+        1.00,
+        "x",
+        2,
+        tooltip="Multiplier on the base lower-leg (shank) segment length (0.70-1.30)."
+        " 1.00 = default anthropometric fraction of height.",
+    )
+    sidebar.ul_slider = LabelledSlider(
+        "Upper Leg (x)",
+        0.70,
+        1.30,
+        1.00,
+        "x",
+        2,
+        tooltip="Multiplier on the base upper-leg (thigh) segment length (0.70-1.30)."
+        " 1.00 = default anthropometric fraction of height.",
+    )
+    sidebar.to_slider = LabelledSlider(
+        "Torso (x)",
+        0.70,
+        1.30,
+        1.00,
+        "x",
+        2,
+        tooltip="Multiplier on the base torso segment length (0.70-1.30)."
+        " 1.00 = default anthropometric fraction of height.",
+    )
     lay.addWidget(sidebar.ll_slider)
     lay.addWidget(sidebar.ul_slider)
     lay.addWidget(sidebar.to_slider)
@@ -60,11 +105,38 @@ def build_barbell(sidebar) -> None:
     hint = QLabel(f"Olympic bar = {BAR_MASS_KG:.0f} kg")
     hint.setProperty("class", "dim")
     lay.addWidget(hint)
-    sidebar.bar_slider = LabelledSlider("Total Bar + Plates", 0, 300, 60, "kg", 0)
+    sidebar.bar_slider = LabelledSlider(
+        "Total Bar + Plates (kg)",
+        0,
+        300,
+        60,
+        "kg",
+        0,
+        tooltip="Combined mass of the barbell and any loaded plates in kilograms (0-300 kg)."
+        " An unloaded Olympic bar weighs 20 kg.",
+    )
     lay.addWidget(sidebar.bar_slider)
-    sidebar.bar_depth_slider = LabelledSlider("Bar Back Offset", 0.0, 0.4, 0.0, "m", 2)
+    sidebar.bar_depth_slider = LabelledSlider(
+        "Bar Back Offset (m)",
+        0.0,
+        0.4,
+        0.0,
+        "m",
+        2,
+        tooltip="Horizontal distance (m) the bar is displaced behind the shoulder contact point"
+        " (0.00-0.40 m). Use for high-bar vs low-bar squat setups.",
+    )
     lay.addWidget(sidebar.bar_depth_slider)
-    sidebar.bar_height_slider = LabelledSlider("Bar Drop Offset", 0.0, 0.4, 0.0, "m", 2)
+    sidebar.bar_height_slider = LabelledSlider(
+        "Bar Drop Offset (m)",
+        0.0,
+        0.4,
+        0.0,
+        "m",
+        2,
+        tooltip="Vertical distance (m) the bar sits below the default shoulder height"
+        " (0.00-0.40 m). Positive values lower the bar contact point.",
+    )
     lay.addWidget(sidebar.bar_height_slider)
     sidebar.main_layout.addWidget(grp)
 
@@ -93,8 +165,26 @@ def build_optimization(sidebar) -> None:
                 )
     model_row.addWidget(sidebar.model_combo)
     lay.addLayout(model_row)
-    sidebar.dur_slider = LabelledSlider("Duration", 0.5, 5.0, 2.0, "s", 1)
-    sidebar.smooth_slider = LabelledSlider("Smoothness", 0.1, 5.0, 1.0, "x", 1)
+    sidebar.dur_slider = LabelledSlider(
+        "Duration (s)",
+        0.5,
+        5.0,
+        2.0,
+        "s",
+        1,
+        tooltip="Total movement duration in seconds (0.5-5.0 s)."
+        " Shorter durations produce faster, more dynamic trajectories.",
+    )
+    sidebar.smooth_slider = LabelledSlider(
+        "Smoothness (x)",
+        0.1,
+        5.0,
+        1.0,
+        "x",
+        1,
+        tooltip="Penalty weight on joint-torque rate of change (0.1-5.0)."
+        " Higher values encourage smoother torque transitions.",
+    )
     hint = QLabel("Higher = smoother torques")
     hint.setProperty("class", "dim")
     lay.addWidget(sidebar.dur_slider)

--- a/src/movement_optimizer/gui/help_dialog.py
+++ b/src/movement_optimizer/gui/help_dialog.py
@@ -144,5 +144,5 @@ class ParameterHelpDialog(QDialog):
         outer.addWidget(scroll)
 
         buttons = QDialogButtonBox(QDialogButtonBox.StandardButton.Close)
-        buttons.rejected.connect(self.accept)
+        buttons.rejected.connect(self.reject)
         outer.addWidget(buttons)

--- a/src/movement_optimizer/gui/help_dialog.py
+++ b/src/movement_optimizer/gui/help_dialog.py
@@ -1,0 +1,148 @@
+# Copyright (c) 2026 D-Sorganization. All rights reserved.
+"""ParameterHelpDialog: scrollable parameter-guide dialog for the Help menu."""
+
+from __future__ import annotations
+
+import logging
+from typing import ClassVar
+
+from PyQt6.QtCore import Qt
+from PyQt6.QtWidgets import (
+    QDialog,
+    QDialogButtonBox,
+    QGridLayout,
+    QLabel,
+    QScrollArea,
+    QVBoxLayout,
+    QWidget,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class ParameterHelpDialog(QDialog):
+    """Shows a scrollable list of parameter descriptions with units and ranges.
+
+    Precondition: parent must be a QWidget or None.
+    """
+
+    PARAMETERS: ClassVar[dict[str, tuple[str, str, str]]] = {
+        "Body Mass": (
+            "Total body mass of the lifter",
+            "kg",
+            "50-150",
+        ),
+        "Height": (
+            "Standing height of the lifter",
+            "m",
+            "1.40-2.10",
+        ),
+        "Lower Leg": (
+            "Multiplier on the base lower-leg segment length (shank). "
+            "Values above 1.0 lengthen the segment; below 1.0 shorten it.",
+            "x",
+            "0.70-1.30",
+        ),
+        "Upper Leg": (
+            "Multiplier on the base upper-leg segment length (thigh). "
+            "Values above 1.0 lengthen the segment; below 1.0 shorten it.",
+            "x",
+            "0.70-1.30",
+        ),
+        "Torso": (
+            "Multiplier on the base torso segment length. "
+            "Values above 1.0 lengthen the segment; below 1.0 shorten it.",
+            "x",
+            "0.70-1.30",
+        ),
+        "Total Bar + Plates": (
+            "Combined mass of the barbell and any loaded plates. An Olympic bar alone is 20 kg.",
+            "kg",
+            "0-300",
+        ),
+        "Bar Back Offset": (
+            "Horizontal distance by which the bar is displaced behind the "
+            "shoulder contact point. Positive values shift the bar rearward.",
+            "m",
+            "0.00-0.40",
+        ),
+        "Bar Drop Offset": (
+            "Vertical distance by which the bar sits below the default "
+            "shoulder height. Positive values lower the bar.",
+            "m",
+            "0.00-0.40",
+        ),
+        "Duration": (
+            "Total time allowed for the movement from start to end position. "
+            "Shorter durations produce faster, more dynamic trajectories.",
+            "s",
+            "0.5-5.0",
+        ),
+        "Smoothness": (
+            "Penalty weight on joint-torque rate of change. Higher values "
+            "encourage smoother, slower torque transitions at the cost of "
+            "slightly higher peak torques.",
+            "x",
+            "0.1-5.0",
+        ),
+    }
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Parameter Guide")
+        self.setMinimumWidth(560)
+        self.setMinimumHeight(480)
+        self._build_ui()
+
+    def _build_ui(self) -> None:
+        outer = QVBoxLayout(self)
+        outer.setContentsMargins(12, 12, 12, 12)
+        outer.setSpacing(8)
+
+        header = QLabel(
+            "Each parameter below controls a physical property of the model. "
+            "Adjust sliders on the left-hand sidebar to change their values."
+        )
+        header.setWordWrap(True)
+        outer.addWidget(header)
+
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+
+        content = QWidget()
+        grid = QGridLayout(content)
+        grid.setContentsMargins(4, 4, 4, 4)
+        grid.setSpacing(6)
+        grid.setColumnStretch(1, 1)
+
+        for col, heading in enumerate(("Parameter", "Description", "Unit", "Range")):
+            lbl = QLabel(f"<b>{heading}</b>")
+            grid.addWidget(lbl, 0, col)
+
+        for row, (name, (desc, unit, rng)) in enumerate(self.PARAMETERS.items(), start=1):
+            name_lbl = QLabel(name)
+            name_lbl.setAlignment(Qt.AlignmentFlag.AlignTop)
+
+            desc_lbl = QLabel(desc)
+            desc_lbl.setWordWrap(True)
+            desc_lbl.setAlignment(Qt.AlignmentFlag.AlignTop)
+
+            unit_lbl = QLabel(unit)
+            unit_lbl.setAlignment(Qt.AlignmentFlag.AlignTop | Qt.AlignmentFlag.AlignHCenter)
+
+            rng_lbl = QLabel(rng)
+            rng_lbl.setAlignment(Qt.AlignmentFlag.AlignTop | Qt.AlignmentFlag.AlignHCenter)
+
+            grid.addWidget(name_lbl, row, 0)
+            grid.addWidget(desc_lbl, row, 1)
+            grid.addWidget(unit_lbl, row, 2)
+            grid.addWidget(rng_lbl, row, 3)
+
+        content.setLayout(grid)
+        scroll.setWidget(content)
+        outer.addWidget(scroll)
+
+        buttons = QDialogButtonBox(QDialogButtonBox.StandardButton.Close)
+        buttons.rejected.connect(self.accept)
+        outer.addWidget(buttons)

--- a/src/movement_optimizer/gui/labelled_slider.py
+++ b/src/movement_optimizer/gui/labelled_slider.py
@@ -21,6 +21,7 @@ class LabelledSlider(QWidget):
         unit: str,
         decimals: int = 1,
         steps: int = 200,
+        tooltip: str = "",
         parent: QWidget | None = None,
     ) -> None:
         super().__init__(parent)
@@ -50,9 +51,11 @@ class LabelledSlider(QWidget):
         self.slider.setRange(0, steps)
         self.slider.setValue(self._to_tick(default))
         self.slider.valueChanged.connect(self._on_change)
-        self.slider.setAccessibleName(label)
-        self.name_label.setBuddy(self.slider)
         layout.addWidget(self.slider)
+
+        _tip = tooltip if tooltip else f"{label} ({lo:.{decimals}f}-{hi:.{decimals}f} {unit})"
+        self.slider.setToolTip(_tip)
+        self.name_label.setToolTip(_tip)
 
     def _fmt(self, val: float) -> str:
         return f"{val:.{self.decimals}f} {self.unit}"

--- a/src/movement_optimizer/gui/main_window.py
+++ b/src/movement_optimizer/gui/main_window.py
@@ -142,8 +142,12 @@ class MainWindow(
     def _build_menu_bar(self) -> None:
         """Add the Help menu to the application menu bar."""
         menu_bar = self.menuBar()
+        if menu_bar is None:
+            return
 
         help_menu = menu_bar.addMenu("&Help")
+        if help_menu is None:
+            return
 
         about_action = QAction("&About", self)
         about_action.setStatusTip("Show information about Movement Optimizer")

--- a/src/movement_optimizer/gui/main_window.py
+++ b/src/movement_optimizer/gui/main_window.py
@@ -23,6 +23,7 @@ from typing import Any
 
 import matplotlib
 from PyQt6.QtCore import QSettings, QTimer, pyqtSignal
+from PyQt6.QtGui import QAction, QKeySequence
 from PyQt6.QtWidgets import (
     QMainWindow,
     QMessageBox,
@@ -38,6 +39,7 @@ from ..trajectory import (
 from .animation_control import AnimationControlMixin
 from .comparison_mixin import ComparisonMixin
 from .file_operations import FileOperationsMixin
+from .help_dialog import ParameterHelpDialog
 from .optimization_mixin import OptimizationMixin
 from .session_state import collect_results, collect_slider_values, restore_slider_values
 from .stylesheet import QSS
@@ -134,7 +136,46 @@ class MainWindow(
             self.status_label,
         ) = build_central_widget(self, self.EXERCISE_CONFIGS)
         self.setCentralWidget(central)
+        self._build_menu_bar()
         self._connect_signals()
+
+    def _build_menu_bar(self) -> None:
+        """Add the Help menu to the application menu bar."""
+        menu_bar = self.menuBar()
+
+        help_menu = menu_bar.addMenu("&Help")
+
+        about_action = QAction("&About", self)
+        about_action.setStatusTip("Show information about Movement Optimizer")
+        about_action.triggered.connect(self._show_about)
+        help_menu.addAction(about_action)
+
+        guide_action = QAction("&Parameter Guide", self)
+        guide_action.setShortcut(QKeySequence("F1"))
+        guide_action.setStatusTip("Open the parameter reference guide")
+        guide_action.triggered.connect(self._show_parameter_guide)
+        help_menu.addAction(guide_action)
+
+    def _show_about(self) -> None:
+        """Display an About dialog with app name, version, and description."""
+        from .. import __version__
+
+        QMessageBox.about(
+            self,
+            "About Movement Optimizer",
+            f"<b>Movement Optimizer</b> v{__version__}<br><br>"
+            "Computes optimal barbell exercise trajectories using Lagrangian "
+            "inverse dynamics in the sagittal plane.<br><br>"
+            "The body is modelled as a 3-link planar chain (shank, thigh, trunk) "
+            "with a barbell load at the top. Trajectories are found via multi-start "
+            "parallel SLSQP optimisation subject to balance and joint constraints.<br><br>"
+            "&#169; 2026 D-Sorganization. All rights reserved.",
+        )
+
+    def _show_parameter_guide(self) -> None:
+        """Open the parameter guide dialog."""
+        dlg = ParameterHelpDialog(self)
+        dlg.exec()
 
     def _connect_signals(self) -> None:
         self.sidebar.connect_action_handlers(


### PR DESCRIPTION
## Summary

- **New `ParameterHelpDialog`** (`src/movement_optimizer/gui/help_dialog.py`): a scrollable QDialog listing every tuneable parameter with its description, unit, and typical range. Opened via Help > Parameter Guide (F1).
- **Help menu** added to `MainWindow` menu bar with two actions: "About" (shows app name, version, description) and "Parameter Guide" (opens the new dialog).
- **`LabelledSlider` tooltip support**: added an optional `tooltip` constructor argument. When omitted, an auto-generated fallback shows the range and unit.
- **All sidebar sliders** now carry meaningful `tooltip=` strings and unit-annotated labels (e.g. "Body Mass (kg)", "Duration (s)", "Smoothness (x)").

## Test plan

- [ ] Launch the app; confirm the menu bar shows a "Help" entry.
- [ ] Click Help > About; confirm a dialog shows the app version and description.
- [ ] Press F1 (or Help > Parameter Guide); confirm the scrollable parameter table opens with all 10 parameters listed.
- [ ] Hover over each sidebar slider; confirm a meaningful tooltip with description, unit, and range appears.
- [ ] Run `PYTHONPATH=src python3 -m pytest tests/test_models.py tests/test_exercises.py tests/test_persistence.py -q` — all pass.
- [ ] Run `ruff check src/ tests/` — no issues.

Closes #414

https://claude.ai/code/session_01N2iX3QcDw2cQ7ajpSUbcbA

---
_Generated by [Claude Code](https://claude.ai/code/session_01N2iX3QcDw2cQ7ajpSUbcbA)_