### PR TITLE
fix(tests): enable GUI tests by setting QT_QPA_PLATFORM=offscreen (#404)

### DIFF
--- a/tests/test_exercise_tab.py
+++ b/tests/test_exercise_tab.py
@@ -8,9 +8,12 @@ deterministic.
 
 from __future__ import annotations
 
+import os
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
 try:
     from PyQt6.QtWidgets import QApplication

--- a/tests/test_gui_widgets.py
+++ b/tests/test_gui_widgets.py
@@ -8,7 +8,11 @@ expected attributes/methods without requiring a running QApplication
 
 from __future__ import annotations
 
+import os
+
 import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
 try:
     from movement_optimizer.gui import MainWindow  # noqa: F401

--- a/tests/test_issue_217_decompose.py
+++ b/tests/test_issue_217_decompose.py
@@ -20,11 +20,14 @@ from __future__ import annotations
 
 import argparse
 import logging
+import os
 from typing import Any
 from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
 try:
     from PyQt6.QtWidgets import QApplication

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -8,11 +8,14 @@ satisfies the protocol expected by the mixin methods.
 
 from __future__ import annotations
 
+import os
 import threading
 from dataclasses import dataclass
 from typing import Any, ClassVar
 
 import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
 try:
     from PyQt6.QtWidgets import QApplication

--- a/tests/test_ui_builder.py
+++ b/tests/test_ui_builder.py
@@ -1,5 +1,10 @@
 # Copyright (c) 2026 D-Sorganization. All rights reserved.
+import os
+
 import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
 from PyQt6.QtWidgets import QLabel, QPushButton, QTabWidget, QWidget
 
 from movement_optimizer.gui.ui_builder import build_central_widget


### PR DESCRIPTION
Sets QT_QPA_PLATFORM=offscreen before PyQt6 imports in test files that previously skipped all tests due to missing display server.

- tests/test_main_window.py
- tests/test_exercise_tab.py
- tests/test_gui_widgets.py
- tests/test_ui_builder.py
- tests/test_issue_217_decompose.py

This allows all 61 GUI tests to run and pass in headless CI environments without requiring Xvfb or a physical display.

Resolves #404