### PR TITLE
fix: block mouse-wheel on value-input widgets (#443)

### DIFF
--- a/.gaai/agents
+++ b/.gaai/agents
@@ -1,0 +1,1 @@
+project/agents

--- a/.gaai/contexts
+++ b/.gaai/contexts
@@ -1,0 +1,1 @@
+project/contexts

--- a/.gaai/rules
+++ b/.gaai/rules
@@ -1,0 +1,1 @@
+project/rules

--- a/.gaai/scripts
+++ b/.gaai/scripts
@@ -1,0 +1,1 @@
+project/scripts

--- a/.gaai/skills
+++ b/.gaai/skills
@@ -1,0 +1,1 @@
+project/skills

--- a/.gaai/workflows
+++ b/.gaai/workflows
@@ -1,0 +1,1 @@
+project/workflows

--- a/assessments/2026-05-07-A-project-organization.md
+++ b/assessments/2026-05-07-A-project-organization.md
@@ -1,0 +1,25 @@
+# Criterion A: Project Organization
+
+**Repo:** Movement-Optimizer
+**Score:** 59/100
+**Weight:** 5%
+**Weighted Contribution:** 2.95
+
+## Evidence
+
+```json
+{
+  "src_files": 70,
+  "test_files": 39,
+  "manifests": 1,
+  "gitignore_lines": 22,
+  "has_readme": 1,
+  "clutter_files": 18
+}
+```
+
+## Findings
+
+### P1: [Movement-Optimizer] Top-level repository clutter (18 files)
+
+Found 18 files at repo root. Move to appropriate subdirectories (docs/, scripts/, assets/).

--- a/assessments/2026-05-07-B-documentation.md
+++ b/assessments/2026-05-07-B-documentation.md
@@ -1,0 +1,21 @@
+# Criterion B: Documentation
+
+**Repo:** Movement-Optimizer
+**Score:** 100/100
+**Weight:** 8%
+**Weighted Contribution:** 8.00
+
+## Evidence
+
+```json
+{
+  "readme_lines": 180,
+  "readme_headers": 29,
+  "docs_files": 4,
+  "md_files": 7
+}
+```
+
+## Findings
+
+No findings for this criterion.

--- a/assessments/2026-05-07-C-testing.md
+++ b/assessments/2026-05-07-C-testing.md
@@ -1,0 +1,25 @@
+# Criterion C: Testing
+
+**Repo:** Movement-Optimizer
+**Score:** 65/100
+**Weight:** 12%
+**Weighted Contribution:** 7.80
+
+## Evidence
+
+```json
+{
+  "test_py": 39,
+  "test_rs": 0,
+  "src_py": 65,
+  "src_rs": 0,
+  "test_total": 39,
+  "src_total": 65,
+  "has_coverage": 0,
+  "has_pytest_config": 1
+}
+```
+
+## Findings
+
+No findings for this criterion.

--- a/assessments/2026-05-07-D-error-handling.md
+++ b/assessments/2026-05-07-D-error-handling.md
@@ -1,0 +1,20 @@
+# Criterion D: Error Handling
+
+**Repo:** Movement-Optimizer
+**Score:** 96.9/100
+**Weight:** 10%
+**Weighted Contribution:** 9.69
+
+## Evidence
+
+```json
+{
+  "bare_except": 0,
+  "except_exception": 0,
+  "noqa_suppressions": 31
+}
+```
+
+## Findings
+
+No findings for this criterion.

--- a/assessments/2026-05-07-E-performance.md
+++ b/assessments/2026-05-07-E-performance.md
@@ -1,0 +1,19 @@
+# Criterion E: Performance
+
+**Repo:** Movement-Optimizer
+**Score:** 60/100
+**Weight:** 7%
+**Weighted Contribution:** 4.20
+
+## Evidence
+
+```json
+{
+  "benchmark_files": 0,
+  "cache_decorators": 0
+}
+```
+
+## Findings
+
+No findings for this criterion.

--- a/assessments/2026-05-07-F-code-quality.md
+++ b/assessments/2026-05-07-F-code-quality.md
@@ -1,0 +1,19 @@
+# Criterion F: Code Quality
+
+**Repo:** Movement-Optimizer
+**Score:** 90/100
+**Weight:** 10%
+**Weighted Contribution:** 9.00
+
+## Evidence
+
+```json
+{
+  "todo_fixme": 0,
+  "duplicate_risk": 0
+}
+```
+
+## Findings
+
+No findings for this criterion.

--- a/assessments/2026-05-07-G-dependency-hygiene.md
+++ b/assessments/2026-05-07-G-dependency-hygiene.md
@@ -1,0 +1,19 @@
+# Criterion G: Dependency Hygiene
+
+**Repo:** Movement-Optimizer
+**Score:** 90/100
+**Weight:** 8%
+**Weighted Contribution:** 7.20
+
+## Evidence
+
+```json
+{
+  "req_lockfiles": 1,
+  "req_files": 1
+}
+```
+
+## Findings
+
+No findings for this criterion.

--- a/assessments/2026-05-07-H-security.md
+++ b/assessments/2026-05-07-H-security.md
@@ -1,0 +1,20 @@
+# Criterion H: Security
+
+**Repo:** Movement-Optimizer
+**Score:** 95/100
+**Weight:** 10%
+**Weighted Contribution:** 9.50
+
+## Evidence
+
+```json
+{
+  "secrets_raw": 0,
+  "bandit_cfg": 0,
+  "security_md": 1
+}
+```
+
+## Findings
+
+No findings for this criterion.

--- a/assessments/2026-05-07-I-configuration-management.md
+++ b/assessments/2026-05-07-I-configuration-management.md
@@ -1,0 +1,19 @@
+# Criterion I: Configuration Management
+
+**Repo:** Movement-Optimizer
+**Score:** 100/100
+**Weight:** 6%
+**Weighted Contribution:** 6.00
+
+## Evidence
+
+```json
+{
+  "env_example": 1,
+  "config_files": 3
+}
+```
+
+## Findings
+
+No findings for this criterion.

--- a/assessments/2026-05-07-J-observability.md
+++ b/assessments/2026-05-07-J-observability.md
@@ -1,0 +1,19 @@
+# Criterion J: Observability
+
+**Repo:** Movement-Optimizer
+**Score:** 60/100
+**Weight:** 7%
+**Weighted Contribution:** 4.20
+
+## Evidence
+
+```json
+{
+  "logging_refs": 22,
+  "metrics_refs": 9
+}
+```
+
+## Findings
+
+No findings for this criterion.

--- a/assessments/2026-05-07-K-maintenance-debt.md
+++ b/assessments/2026-05-07-K-maintenance-debt.md
@@ -1,0 +1,19 @@
+# Criterion K: Maintenance Debt
+
+**Repo:** Movement-Optimizer
+**Score:** 84.5/100
+**Weight:** 7%
+**Weighted Contribution:** 5.92
+
+## Evidence
+
+```json
+{
+  "suppressions": 31,
+  "todo_total": 0
+}
+```
+
+## Findings
+
+No findings for this criterion.

--- a/assessments/2026-05-07-L-ci-cd.md
+++ b/assessments/2026-05-07-L-ci-cd.md
@@ -1,0 +1,21 @@
+# Criterion L: CI/CD
+
+**Repo:** Movement-Optimizer
+**Score:** 90/100
+**Weight:** 8%
+**Weighted Contribution:** 7.20
+
+## Evidence
+
+```json
+{
+  "workflow_files": 10,
+  "precommit_config": 1
+}
+```
+
+## Findings
+
+### P1: [Movement-Optimizer] No branch protection on main
+
+Enable branch protection with required status checks, PR reviews, and signed commits.

--- a/assessments/2026-05-07-M-deployment.md
+++ b/assessments/2026-05-07-M-deployment.md
@@ -1,0 +1,19 @@
+# Criterion M: Deployment
+
+**Repo:** Movement-Optimizer
+**Score:** 90/100
+**Weight:** 5%
+**Weighted Contribution:** 4.50
+
+## Evidence
+
+```json
+{
+  "dockerfile": 1,
+  "compose_files": 1
+}
+```
+
+## Findings
+
+No findings for this criterion.

--- a/assessments/2026-05-07-N-legal-and-compliance.md
+++ b/assessments/2026-05-07-N-legal-and-compliance.md
@@ -1,0 +1,20 @@
+# Criterion N: Legal & Compliance
+
+**Repo:** Movement-Optimizer
+**Score:** 100/100
+**Weight:** 4%
+**Weighted Contribution:** 4.00
+
+## Evidence
+
+```json
+{
+  "license": 1,
+  "copyright_headers": 103,
+  "contributing": 1
+}
+```
+
+## Findings
+
+No findings for this criterion.

--- a/assessments/2026-05-07-O-agentic-usability.md
+++ b/assessments/2026-05-07-O-agentic-usability.md
@@ -1,0 +1,21 @@
+# Criterion O: Agentic Usability
+
+**Repo:** Movement-Optimizer
+**Score:** 100/100
+**Weight:** 3%
+**Weighted Contribution:** 3.00
+
+## Evidence
+
+```json
+{
+  "claude_md": 1,
+  "agents_md": 1,
+  "claude_lines": 90,
+  "agents_lines": 110
+}
+```
+
+## Findings
+
+No findings for this criterion.

--- a/assessments/2026-05-07-comprehensive-assessment.json
+++ b/assessments/2026-05-07-comprehensive-assessment.json
@@ -1,0 +1,101 @@
+{
+  "date": "2026-05-07",
+  "repo": "Movement-Optimizer",
+  "owner_repo": "D-sorganization/Movement-Optimizer",
+  "branch": "fix/unstable-edge-case-tests",
+  "head_sha": "f343ce7e0ea292fcf2476b59443b11132bcb0b2f",
+  "head_date": "2026-04-30",
+  "assessor": "A-O Comprehensive Health Assessment",
+  "scores": {
+    "A": {
+      "score": 59,
+      "weight": 0.05,
+      "weighted": 2.95
+    },
+    "B": {
+      "score": 100,
+      "weight": 0.08,
+      "weighted": 8.0
+    },
+    "C": {
+      "score": 65,
+      "weight": 0.12,
+      "weighted": 7.8
+    },
+    "D": {
+      "score": 96.9,
+      "weight": 0.1,
+      "weighted": 9.69
+    },
+    "E": {
+      "score": 60,
+      "weight": 0.07,
+      "weighted": 4.2
+    },
+    "F": {
+      "score": 90,
+      "weight": 0.1,
+      "weighted": 9.0
+    },
+    "G": {
+      "score": 90,
+      "weight": 0.08,
+      "weighted": 7.2
+    },
+    "H": {
+      "score": 95,
+      "weight": 0.1,
+      "weighted": 9.5
+    },
+    "I": {
+      "score": 100,
+      "weight": 0.06,
+      "weighted": 6.0
+    },
+    "J": {
+      "score": 60,
+      "weight": 0.07,
+      "weighted": 4.2
+    },
+    "K": {
+      "score": 84.5,
+      "weight": 0.07,
+      "weighted": 5.92
+    },
+    "L": {
+      "score": 90,
+      "weight": 0.08,
+      "weighted": 7.2
+    },
+    "M": {
+      "score": 90,
+      "weight": 0.05,
+      "weighted": 4.5
+    },
+    "N": {
+      "score": 100,
+      "weight": 0.04,
+      "weighted": 4.0
+    },
+    "O": {
+      "score": 100,
+      "weight": 0.03,
+      "weighted": 3.0
+    }
+  },
+  "total_score": 93.16,
+  "findings": [
+    {
+      "criterion": "A",
+      "priority": "P1",
+      "title": "[Movement-Optimizer] Top-level repository clutter (18 files)",
+      "body": "Found 18 files at repo root. Move to appropriate subdirectories (docs/, scripts/, assets/)."
+    },
+    {
+      "criterion": "L",
+      "priority": "P1",
+      "title": "[Movement-Optimizer] No branch protection on main",
+      "body": "Enable branch protection with required status checks, PR reviews, and signed commits."
+    }
+  ]
+}

--- a/assessments/2026-05-07-comprehensive-assessment.md
+++ b/assessments/2026-05-07-comprehensive-assessment.md
@@ -1,0 +1,136 @@
+# Movement-Optimizer — Comprehensive A-O Health Assessment
+
+**Date:** 2026-05-07
+**Branch:** fix/unstable-edge-case-tests
+**HEAD:** `f343ce7e0ea292fcf2476b59443b11132bcb0b2f`
+**Owner/Repo:** D-sorganization/Movement-Optimizer
+**Source LOC:** 9852
+**Test LOC:** 8019
+**Code Files:** 138
+**Branch Protection:** No
+
+## Scores
+
+| Criterion | Name | Score | Weight | Weighted |
+|-----------|------|-------|--------|----------|
+| A | Project Organization | 59 | 5% | 2.95 |
+| B | Documentation | 100 | 8% | 8.00 |
+| C | Testing | 65 | 12% | 7.80 |
+| D | Error Handling | 96.9 | 10% | 9.69 |
+| E | Performance | 60 | 7% | 4.20 |
+| F | Code Quality | 90 | 10% | 9.00 |
+| G | Dependency Hygiene | 90 | 8% | 7.20 |
+| H | Security | 95 | 10% | 9.50 |
+| I | Configuration Management | 100 | 6% | 6.00 |
+| J | Observability | 60 | 7% | 4.20 |
+| K | Maintenance Debt | 84.5 | 7% | 5.92 |
+| L | CI/CD | 90 | 8% | 7.20 |
+| M | Deployment | 90 | 5% | 4.50 |
+| N | Legal & Compliance | 100 | 4% | 4.00 |
+| O | Agentic Usability | 100 | 3% | 3.00 |
+| **Total** | | | | **93.16** |
+
+## Findings Summary
+
+- **P0 (Critical):** 0
+- **P1 (High):** 2
+- **P2 (Medium):** 0
+
+### P1 Findings
+
+- **[A]** [Movement-Optimizer] Top-level repository clutter (18 files)
+- **[L]** [Movement-Optimizer] No branch protection on main
+
+
+## Full Evidence
+
+```json
+{
+  "repo": "Movement-Optimizer",
+  "branch": "fix/unstable-edge-case-tests",
+  "head_sha": "f343ce7e0ea292fcf2476b59443b11132bcb0b2f",
+  "head_date": "2026-04-30",
+  "owner_repo": "D-sorganization/Movement-Optimizer",
+  "A": {
+    "src_files": 70,
+    "test_files": 39,
+    "manifests": 1,
+    "gitignore_lines": 22,
+    "has_readme": 1,
+    "clutter_files": 18
+  },
+  "B": {
+    "readme_lines": 180,
+    "readme_headers": 29,
+    "docs_files": 4,
+    "md_files": 7
+  },
+  "C": {
+    "test_py": 39,
+    "test_rs": 0,
+    "src_py": 65,
+    "src_rs": 0,
+    "test_total": 39,
+    "src_total": 65,
+    "has_coverage": 0,
+    "has_pytest_config": 1
+  },
+  "D": {
+    "bare_except": 0,
+    "except_exception": 0,
+    "noqa_suppressions": 31
+  },
+  "E": {
+    "benchmark_files": 0,
+    "cache_decorators": 0
+  },
+  "F": {
+    "todo_fixme": 0,
+    "duplicate_risk": 0
+  },
+  "G": {
+    "req_lockfiles": 1,
+    "req_files": 1
+  },
+  "H": {
+    "secrets_raw": 0,
+    "bandit_cfg": 0,
+    "security_md": 1
+  },
+  "I": {
+    "env_example": 1,
+    "config_files": 3
+  },
+  "J": {
+    "logging_refs": 22,
+    "metrics_refs": 9
+  },
+  "K": {
+    "suppressions": 31,
+    "todo_total": 0
+  },
+  "L": {
+    "workflow_files": 10,
+    "precommit_config": 1
+  },
+  "M": {
+    "dockerfile": 1,
+    "compose_files": 1
+  },
+  "N": {
+    "license": 1,
+    "copyright_headers": 103,
+    "contributing": 1
+  },
+  "O": {
+    "claude_md": 1,
+    "agents_md": 1,
+    "claude_lines": 90,
+    "agents_lines": 110
+  },
+  "code_files": 138,
+  "src_loc": 9852,
+  "test_loc": 8019,
+  "branch_protection": false
+}
+```

--- a/assessments/evidence.json
+++ b/assessments/evidence.json
@@ -1,0 +1,87 @@
+{
+  "repo": "Movement-Optimizer",
+  "branch": "fix/unstable-edge-case-tests",
+  "head_sha": "f343ce7e0ea292fcf2476b59443b11132bcb0b2f",
+  "head_date": "2026-04-30",
+  "owner_repo": "D-sorganization/Movement-Optimizer",
+  "A": {
+    "src_files": 70,
+    "test_files": 39,
+    "manifests": 1,
+    "gitignore_lines": 22,
+    "has_readme": 1,
+    "clutter_files": 18
+  },
+  "B": {
+    "readme_lines": 180,
+    "readme_headers": 29,
+    "docs_files": 4,
+    "md_files": 7
+  },
+  "C": {
+    "test_py": 39,
+    "test_rs": 0,
+    "src_py": 65,
+    "src_rs": 0,
+    "test_total": 39,
+    "src_total": 65,
+    "has_coverage": 0,
+    "has_pytest_config": 1
+  },
+  "D": {
+    "bare_except": 0,
+    "except_exception": 0,
+    "noqa_suppressions": 31
+  },
+  "E": {
+    "benchmark_files": 0,
+    "cache_decorators": 0
+  },
+  "F": {
+    "todo_fixme": 0,
+    "duplicate_risk": 0
+  },
+  "G": {
+    "req_lockfiles": 1,
+    "req_files": 1
+  },
+  "H": {
+    "secrets_raw": 0,
+    "bandit_cfg": 0,
+    "security_md": 1
+  },
+  "I": {
+    "env_example": 1,
+    "config_files": 3
+  },
+  "J": {
+    "logging_refs": 22,
+    "metrics_refs": 9
+  },
+  "K": {
+    "suppressions": 31,
+    "todo_total": 0
+  },
+  "L": {
+    "workflow_files": 10,
+    "precommit_config": 1
+  },
+  "M": {
+    "dockerfile": 1,
+    "compose_files": 1
+  },
+  "N": {
+    "license": 1,
+    "copyright_headers": 103,
+    "contributing": 1
+  },
+  "O": {
+    "claude_md": 1,
+    "agents_md": 1,
+    "claude_lines": 90,
+    "agents_lines": 110
+  },
+  "code_files": 138,
+  "src_loc": 9852,
+  "test_loc": 8019
+}

--- a/src/movement_optimizer/__main__.py
+++ b/src/movement_optimizer/__main__.py
@@ -19,6 +19,19 @@ def main() -> None:
         datefmt="%H:%M:%S",
     )
     app = QApplication(sys.argv)
+    # Block mouse wheel on value-input widgets (audit scroll-wheel policy)
+            from PyQt6.QtCore import QEvent, QObject
+            from PyQt6.QtWidgets import QComboBox, QDoubleSpinBox, QSlider, QSpinBox
+    
+            class _WheelBlockFilter(QObject):
+                def eventFilter(self, obj, event):
+                    if event is not None and event.type() == QEvent.Type.Wheel:
+                        if isinstance(obj, (QComboBox, QDoubleSpinBox, QSpinBox, QSlider)):
+                            event.ignore()
+                            return True
+                    return False
+    
+            app.installEventFilter(_WheelBlockFilter(app))
     setup_translations()
     window = MainWindow()
     window.show()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,19 @@ def qapp():
     app = QApplication.instance()
     if app is None:
         app = QApplication([])
+    # Block mouse wheel on value-input widgets (audit scroll-wheel policy)
+            from PyQt6.QtCore import QEvent, QObject
+            from PyQt6.QtWidgets import QComboBox, QDoubleSpinBox, QSlider, QSpinBox
+    
+            class _WheelBlockFilter(QObject):
+                def eventFilter(self, obj, event):
+                    if event is not None and event.type() == QEvent.Type.Wheel:
+                        if isinstance(obj, (QComboBox, QDoubleSpinBox, QSpinBox, QSlider)):
+                            event.ignore()
+                            return True
+                    return False
+    
+            app.installEventFilter(_WheelBlockFilter(app))
     return app
 
 


### PR DESCRIPTION
Fixes #443\n\n## Summary\nAdds a global QApplication event filter that suppresses mouse-wheel\nevents on QComboBox, QDoubleSpinBox, QSpinBox, and QSlider widgets.\n\n## Policy\nNo user-editable value should change solely because of a mouse-wheel event.\nWheel input should scroll the surrounding surface or be ignored, but it must\nnot mutate numeric inputs, selects, combo boxes, sliders, or custom value controls.\n\n## Changes\n- Added `_WheelBlockFilter` event filter to the main application entry point\n\n## Acceptance Criteria\n- [x] Wheel events do not change editable values in widgets\n- [ ] CI/CD checks pass