### PR TITLE
chore(testing): adopt fleet testing standards Phase 1 (#449)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dev = [
     "mypy>=1.10",
     "pytest>=8.0",
     "pytest-cov>=5.0",
+    "pytest-timeout>=2.3",
     "hypothesis>=6.0",
     "tomli>=2.0; python_version < '3.11'",
     "PyYAML>=6.0",
@@ -61,7 +62,48 @@ known-first-party = ["movement_optimizer"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 pythonpath = ["src", "tests"]
-addopts = "-v --tb=short -p no:xvfb"
+python_files = "test_*.py"
+python_classes = "Test*"
+python_functions = "test_*"
+timeout = 60
+timeout_method = "thread"
+
+# Default lane: fast, deterministic, offline.
+# See: D-sorganization/Repository_Management docs/FLEET_TESTING_STANDARDS.md §2
+addopts = """
+  -v
+  --tb=short
+  -p no:xvfb
+  -ra
+  --strict-markers
+  --strict-config
+  --durations=20
+  -m "not slow and not live_simulation and not e2e and not requires_network"
+"""
+
+markers = [
+  # ---- tier markers ----
+  "unit: pure logic, fully mocked, < 100 ms wall-clock",
+  "integration: cross-module / file-system / process boundaries, < 5 s",
+  "e2e: full-stack smoke tests; nightly + release gate only",
+  "slow: > 1 s wall-clock; deselect with -m 'not slow'",
+  "live_simulation: requires a real physics / math engine; deselect by default",
+
+  # ---- environment markers ----
+  "requires_network: needs real outbound network; deselect by default",
+  "requires_gpu: needs CUDA / Metal / ROCm",
+  "requires_gl: needs OpenGL or a display",
+  "headless_safe: verified under QT_QPA_PLATFORM=offscreen",
+
+  # ---- per-engine markers ----
+  "requires_qt: skip when PyQt6 bindings unavailable",
+  "requires_rust: skip when the maturin-built Rust extension is unavailable",
+
+  # ---- workflow markers ----
+  "serial: must run with -n 0 (xdist parallel breaks this test)",
+  "benchmark: deterministic perf smoke; not a primary correctness gate",
+  "smoke: release-blocking smoke; subset of e2e",
+]
 
 [tool.mypy]
 ignore_missing_imports = true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,26 @@
 
 from __future__ import annotations
 
+# ---------------------------------------------------------------------------
+# Fleet Testing Standards §5: environment setup BEFORE heavy imports.
+# See: D-sorganization/Repository_Management docs/FLEET_TESTING_STANDARDS.md
+# ---------------------------------------------------------------------------
+import os
+
+# C-extension thread safety. Movement-Optimizer uses numpy/scipy (MKL/OpenBLAS)
+# heavily; pin to single-threaded to avoid xdist worker crashes from MKL/
+# OpenBLAS forking. Production code can re-thread itself if needed.
+os.environ.setdefault("OMP_NUM_THREADS", "1")
+os.environ.setdefault("OPENBLAS_NUM_THREADS", "1")
+os.environ.setdefault("MKL_NUM_THREADS", "1")
+os.environ.setdefault("NUMEXPR_NUM_THREADS", "1")
+
+# matplotlib headless backend, set before any matplotlib import.
+os.environ.setdefault("MPLBACKEND", "Agg")
+
+# Qt headless backend, since this repo's GUI is PyQt6.
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
 import numpy as np
 import pytest
 


### PR DESCRIPTION
## Summary

Phase 1 adoption of the canonical fleet testing configuration from
`Repository_Management/docs/FLEET_TESTING_STANDARDS.md` (§2 and §5).

- `pyproject.toml`: additive merge of the standard `[tool.pytest.ini_options]` block. Adds `--strict-markers --strict-config`, the standard tier/environment/workflow markers, default-lane deselection (`not slow and not live_simulation and not e2e and not requires_network`), `--durations=20`, and a 60s per-test timeout. Preserves existing `-v --tb=short -p no:xvfb`, `pythonpath`, and `testpaths`.
- `tests/conftest.py`: adds §5 env block BEFORE heavy imports — single-threaded MKL/OpenBLAS/OMP/NUMEXPR for xdist stability with numpy/scipy, `MPLBACKEND=Agg`, and `QT_QPA_PLATFORM=offscreen` for the PyQt6 GUI surface.
- Adds `pytest-timeout>=2.3` to dev deps.

No network surface in `src/` (no `httpx`/`requests`/`aiohttp`), so the §5 network-blocker fixture is intentionally omitted.

## Audit (pre-change baseline)

| Metric | Value |
|---|---|
| Test files | 43 |
| Tests collected | 673 |
| `pytest --collect-only -q` wall time | ~68s |
| Collection errors | 3 (pre-existing local Qt DLL issue, unrelated to this change) |
| Tier (Applications) | 75% coverage target |

`pytest --collect-only -q` post-change still collects 673 tests; no new strict-marker errors (no custom marks in use today beyond pytest builtins).

## Scope

Phase 1 only. Phase 2 (marker backfill across the 673 tests) is tracked separately.

Closes part of D-sorganization/Movement_Optimizer#449.
Refs EPIC D-sorganization/Repository_Management#1140.

## Test plan

- [ ] CI: default lane passes with new strict-markers config
- [ ] CI: collection still succeeds (673 tests)
- [ ] No regression in existing tests

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>