### PR TITLE
test(coverage): raise fail_under 53 -> 58 (Phase 4 step 1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,5 +105,11 @@ markers = [
   "smoke: release-blocking smoke; subset of e2e",
 ]
 
+[tool.coverage.report]
+# Fleet testing Phase 4: ratcheting coverage floor toward Applications-tier target of 75%.
+# Actual measured coverage on main is ~79.9% (CI runs against Python 3.10/3.11/3.12).
+# Step 1: 53 -> 58. Refs: D-sorganization/Repository_Management#1140
+fail_under = 58
+
 [tool.mypy]
 ignore_missing_imports = true


### PR DESCRIPTION
## Summary

Phase 4 step 1: ratchet the project-level coverage floor.

- Adds `[tool.coverage.report] fail_under = 58` to `pyproject.toml` (previously absent at the project level; CI workflow gate was 53).
- Movement-Optimizer is in the **Applications** tier (target **75%**).
- Actual measured coverage on main is ~79.9% (CI runs against Python 3.10/3.11/3.12), so 58 is comfortably below the real number.

Subsequent Phase 4 steps will ratchet +5 each until the 75% Applications-tier target is reached.

Refs: EPIC D-sorganization/Repository_Management#1140

## Test plan

- [ ] CI Standard green on this branch (existing `--cov-fail-under=53` in the workflow continues to pass; new pyproject floor of 58 also satisfied because actual ~79.9%).
- [ ] No code or test changes; pure configuration ratchet.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>