### PR TITLE
ci: add nightly full-default-lane workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   nightly:
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,49 @@
+name: Nightly Tests
+on:
+  schedule:
+    - cron: "0 7 * * *"  # 07:00 UTC daily
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  nightly:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.11" }
+
+      - name: Install System Dependencies
+        run: |
+          if command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+            sudo apt-get update
+            sudo apt-get install -y libegl1 xvfb
+          fi
+
+      - name: Install
+        run: |
+          python -m pip install -U pip
+          pip install -e ".[test,dev]" || pip install -e ".[test]" || pip install -e ".[dev]" || pip install -e .
+
+      - name: Nightly full default-lane (excludes live_simulation only)
+        env:
+          QT_QPA_PLATFORM: offscreen
+        run: |
+          xvfb-run -a python -m pytest -m "not live_simulation" --durations=20
+
+      - name: Notify on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `Nightly tests failed: ${context.runId}`,
+              body: `Nightly run failed. See https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              labels: ['ci-failure', 'nightly']
+            });


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/nightly.yml` running the full default test lane on a 07:00 UTC daily cron + `workflow_dispatch`.
- Excludes only the `live_simulation` pytest marker (per §9 default lane definition).
- Opens a `ci-failure` / `nightly` labeled issue on failure for triage.

Implements EPIC #1140 §9 (CI shape) — see [FLEET_TESTING_STANDARDS.md §9](https://github.com/D-sorganization/Repository_Management/blob/main/docs/FLEET_TESTING_STANDARDS.md#9-ci-shape). Required jobs: `unit`, `integration`, `nightly`, `release`. This PR adds the `nightly` job; PR-time `unit`/`integration` already covered by `ci-standard.yml`.

## Test plan
- [ ] Workflow YAML is syntactically valid (parsed by GitHub on push).
- [ ] Trigger via `workflow_dispatch` after merge to confirm install + pytest steps run.
- [ ] First scheduled run at next 07:00 UTC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)