### PR TITLE
test(coverage): raise fail_under 58 -> 63 (Phase 4 step 2)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,8 +108,8 @@ markers = [
 [tool.coverage.report]
 # Fleet testing Phase 4: ratcheting coverage floor toward Applications-tier target of 75%.
 # Actual measured coverage on main is ~79.9% (CI runs against Python 3.10/3.11/3.12).
-# Step 1: 53 -> 58. Refs: D-sorganization/Repository_Management#1140
-fail_under = 58
+# Step 1: 53 -> 58. Step 2: 58 -> 63. Refs: D-sorganization/Repository_Management#1140
+fail_under = 63
 
 [tool.mypy]
 ignore_missing_imports = true


### PR DESCRIPTION
## Summary
Fleet testing Phase 4, step 2 for Movement_Optimizer (Applications-tier target 75%).

- Raises coverage floor `fail_under` from 58 to 63 in `pyproject.toml`.
- Measured coverage on main is ~79.9%, so 63 is safe.

## Refs
- EPIC: D-sorganization/Repository_Management#1140
- Step 1 PR: #452

## Test plan
- [ ] CI green across Python 3.10/3.11/3.12

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>