### PR TITLE
test(coverage): raise fail_under 58 -> 63 (Phase 4 step 2)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,8 +108,8 @@ markers = [
 [tool.coverage.report]
 # Fleet testing Phase 4: ratcheting coverage floor toward Applications-tier target of 75%.
 # Actual measured coverage on main is ~79.9% (CI runs against Python 3.10/3.11/3.12).
-# Step 1: 53 -> 58. Refs: D-sorganization/Repository_Management#1140
-fail_under = 58
+# Step 1: 53 -> 58. Step 2: 58 -> 63. Refs: D-sorganization/Repository_Management#1140
+fail_under = 63
 
 [tool.mypy]
 ignore_missing_imports = true


### PR DESCRIPTION
Phase 4 step 2 — EPIC #1140. Tier target: 75 (Applications). Prior step: PR #452 (added fail_under=58).