### PR TITLE
fix(deps): cap scipy below 1.16 to avoid private _promote import

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,13 @@ license = {text = "MIT"}
 requires-python = ">=3.10"
 dependencies = [
     "numpy>=1.24,<2.0",
-    "scipy>=1.10,<2.0",
+    # Cap below 1.16: scipy 1.16+ added scipy.spatial.transform._rigid_transform
+    # which imports a private `_promote` symbol that does not exist in the
+    # compiled _rotation extension installed alongside, breaking
+    # `from scipy.interpolate import CubicSpline` at conftest import time.
+    # Closes #458 (nightly ImportError). Revisit once upstream fixes the
+    # private-API drift.
+    "scipy>=1.10,<1.16",
     "matplotlib>=3.7,<4.0",
     "PyQt6>=6.5,<7.0",
     "openpyxl>=3.1",


### PR DESCRIPTION
## Summary
- Nightly run [25721594303](https://github.com/D-sorganization/Movement_Optimizer/actions/runs/25721594303) failed at conftest import time with:
  `ImportError: cannot import name '_promote' from 'scipy.spatial.transform._rotation'`
- Root cause is upstream: scipy 1.16 added `scipy.spatial.transform._rigid_transform`, whose module-level body does `from scipy.spatial.transform._rotation import _promote`. In affected install environments the compiled `_rotation` extension does not export `_promote`, so importing `scipy.spatial` (transitively pulled in via `from scipy.interpolate import CubicSpline` in `src/movement_optimizer/trajectory/optimizer.py`) blows up. Our own code never touches `_promote`.
- Surgical fix: tighten the pyproject dependency from `scipy>=1.10,<2.0` to `scipy>=1.10,<1.16`. The lockfile (`requirements-lock.txt`) already pins `scipy==1.15.3` (last-known-good); this aligns the loose pin with the lockfile so unpinned installs (e.g. nightly `pip install -e ".[test,dev]"`) cannot regress.

## Verification
- `pip install -e ".[dev]"` resolves scipy 1.13.1 / 1.15.x locally, well under the cap.
- `python -c "from scipy.interpolate import CubicSpline; from scipy.spatial import transform"` no longer errors.
- `python -c "import tests.conftest"` loads cleanly.
- `PYTHONPATH=src python -m pytest tests/test_models.py -x -q` -> 47 passed.
- `ruff check pyproject.toml` + `ruff format --check pyproject.toml` -> clean.

## Test plan
- [x] Local: representative pytest file passes after pin
- [x] Local: scipy.spatial / scipy.interpolate import cleanly
- [x] ruff check / ruff format clean
- [ ] CI: ci-standard.yml green
- [ ] Nightly: next scheduled `Nightly Tests` run no longer hits the `_promote` ImportError

## Notes for future
- I grepped the repo for `_promote`, `_rotation`, and `^from scipy.` -- no private-scipy imports anywhere in MO source or tests. Only public surfaces are used: `scipy.interpolate.CubicSpline`, `scipy.optimize.minimize`, `scipy.optimize.brentq`. So the cap is purely about avoiding an upstream-broken release; once scipy fixes the private-API drift across `_rotation` / `_rigid_transform`, we can relax it.

Closes #458

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>