### PR TITLE
fix(ci): add timeout-minutes:5 to pip-audit step (hang protection)

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -119,6 +119,7 @@ jobs:
           path: bandit_output.json
 
       - name: Security Audit (pip-audit)
+        timeout-minutes: 5
         run: |
           python -m pip install pip-audit
           pip-audit || echo "::warning::pip-audit found vulnerabilities — review before merging"


### PR DESCRIPTION
pip-audit hangs indefinitely on overloaded runners with no step-level timeout, eventually getting OOM-killed and showing as cancelled (not failed). This poisons CI status across the fleet. Adding timeout-minutes:5 kills the step cleanly with a proper failure. Already fixed on main in OpenSim_Models, Pinocchio_Models, MuJoCo_Models.