### PR TITLE
fix(workflows): repair pre-existing broken workflow YAMLs

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           cache: 'pip'
-        with: { python-version: "3.12" }
+          python-version: "3.12"
 
       - name: Install System Dependencies
         run: |
@@ -143,7 +143,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           cache: 'pip'
-        with: { python-version: "${{ matrix.python-version }}" }
+          python-version: "${{ matrix.python-version }}"
 
       - name: Install System Dependencies
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           cache: 'pip'
-        with: { python-version: "3.11" }
+          python-version: "3.11"
 
       - name: Install System Dependencies
         run: |


### PR DESCRIPTION
Repairs workflow files that had duplicate with: keys causing parse failures. Follows same fix pattern as UpstreamDrift PR #5669. Unblocks CI for this repo.

## Fixes
- ci-standard.yml: merged duplicate with: keys on 2 setup-python steps (quality-gate and matrix tests)
- nightly.yml: merged duplicate with: keys on setup-python step